### PR TITLE
fix: Windows compatibility for CLI spawn and npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "start": "node bin/flightdeck.mjs",
     "prepublishOnly": "npm run build",
     "predev": "npm run build:shared",
-    "build:shared": "cd packages/shared && rm -f tsconfig.tsbuildinfo && npm run build",
+    "build:shared": "cd packages/shared && node -e \"try{require('fs').unlinkSync('tsconfig.tsbuildinfo')}catch{}\" && npm run build",
     "dev": "node scripts/dev.mjs",
     "predev:server": "npm run build:shared",
     "dev:server": "npm run dev --workspace=packages/server",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "predev": "cd ../shared && rm -f tsconfig.tsbuildinfo && npm run build",
+    "predev": "cd ../shared && node -e \"try{require('fs').unlinkSync('tsconfig.tsbuildinfo')}catch{}\" && npm run build",
     "dev": "tsx watch src/index.ts",
     "build": "tsc --build",
     "start": "node dist/index.js",

--- a/packages/server/src/adapters/AcpAdapter.ts
+++ b/packages/server/src/adapters/AcpAdapter.ts
@@ -200,6 +200,7 @@ export class AcpAdapter extends EventEmitter implements AgentAdapter {
     this.process = spawn(opts.cliCommand, args, {
       stdio: ['pipe', 'pipe', 'inherit'],
       cwd: opts.cwd || process.cwd(),
+      shell: process.platform === 'win32',
       ...(opts.env ? { env: { ...process.env, ...opts.env } } : {}),
     });
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -14,6 +14,7 @@ function startServer() {
     const proc = spawn('npm', ['run', 'dev', '--workspace=packages/server'], {
       stdio: ['inherit', 'pipe', 'inherit'],
       env: { ...process.env },
+      shell: true,
     });
 
     let resolved = false;
@@ -48,6 +49,7 @@ function startVite(serverPort) {
   return spawn('npm', ['run', 'dev', '--workspace=packages/web'], {
     stdio: 'inherit',
     env: { ...process.env, SERVER_PORT: serverPort },
+    shell: true,
   });
 }
 


### PR DESCRIPTION
  
   - Add shell: true on Windows for agent CLI spawn to avoid ENOENT with .cmd files
   - Replace rm -f with Node.js fs.unlinkSync in build:shared scripts
   - Add shell: true to spawn() calls in scripts/dev.mjs