### PR TITLE
fix: Remove redundant model/role from agent memory

### DIFF
--- a/packages/server/src/__tests__/CommandDispatcher.test.ts
+++ b/packages/server/src/__tests__/CommandDispatcher.test.ts
@@ -722,12 +722,24 @@ describe('CommandDispatcher', () => {
         leadAgent.cwd,
         undefined, // options (non-lead, no projectName)
       );
-      // Memory stores model
+      // Memory stores task but NOT model (model is already in crew roster)
       expect(ctx.agentMemory.store).toHaveBeenCalledWith(
         leadAgent.id,
         newChild.id,
+        'task',
+        'build',
+      );
+      expect(ctx.agentMemory.store).not.toHaveBeenCalledWith(
+        leadAgent.id,
+        newChild.id,
         'model',
-        'claude-opus-4',
+        expect.anything(),
+      );
+      expect(ctx.agentMemory.store).not.toHaveBeenCalledWith(
+        leadAgent.id,
+        newChild.id,
+        'role',
+        expect.anything(),
       );
     });
   });

--- a/packages/server/src/agents/commands/AgentLifecycle.ts
+++ b/packages/server/src/agents/commands/AgentLifecycle.ts
@@ -153,8 +153,9 @@ function handleCreateAgent(ctx: CommandHandlerContext, agent: Agent, data: strin
       }, ctx.getProjectIdForAgent(agent.id) ?? '');
     }
 
-    ctx.agentMemory.store(agent.id, child.id, 'role', role.name);
-    if (req.model) ctx.agentMemory.store(agent.id, child.id, 'model', req.model);
+    // Record task in agent memory — role and model are omitted since they're
+    // already shown in the crew roster and the stored model can be wrong after
+    // system upgrades (it captures the requested model, not the actual one).
     if (req.task) ctx.agentMemory.store(agent.id, child.id, 'task', req.task.slice(0, 200));
 
     maybeSuggestDagGroup(ctx, agent.id);

--- a/packages/server/src/agents/commands/SystemCommands.ts
+++ b/packages/server/src/agents/commands/SystemCommands.ts
@@ -80,7 +80,10 @@ function handleQueryCrew(ctx: CommandHandlerContext, agent: Agent): void {
     const memories = ctx.agentMemory.getByLead(agent.id);
     if (memories.length > 0) {
       const byAgent = new Map<string, MemoryEntry[]>();
+      // Filter out role and model — already in crew roster, stored model can be stale
+      const REDUNDANT_KEYS = new Set(['role', 'model']);
       for (const m of memories) {
+        if (REDUNDANT_KEYS.has(m.key)) continue;
         const list = byAgent.get(m.agentId) || [];
         list.push(m);
         byAgent.set(m.agentId, list);
@@ -90,7 +93,9 @@ function handleQueryCrew(ctx: CommandHandlerContext, agent: Agent): void {
         const facts = entries.map(e => `${e.key}: ${e.value}`).join(', ');
         lines.push(`  - ${agentId.slice(0, 8)}: ${facts}`);
       }
+      if (lines.length > 0) {
       memorySection = `== AGENT MEMORY ==\nRecorded facts about your agents:\n${lines.join('\n')}`;
+      }
     }
   }
 


### PR DESCRIPTION
Agent memory (shown in QUERY_CREW) was storing model and role for each agent, which are already displayed in the crew roster table. Worse, the stored values could be wrong (recording the requested model, not the actual one after system upgrades). Fix: stop recording model/role in agent memory, filter stale entries from display. Only task, context, and sessionId are stored now.