### PR TITLE
refactor: Eliminate project:xxx temporary key pattern

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -73,11 +73,7 @@ function ProjectRedirect({ page }: { page: string }) {
       const firstLead = agents.find((a) => a.role?.id === 'lead' && !a.parentId);
       return firstLead?.projectId ?? firstLead?.id ?? null;
     }
-    // If selectedLeadId is a project: prefix, extract the ID
-    if (selectedLeadId.startsWith('project:')) {
-      return selectedLeadId.slice('project:'.length);
-    }
-    // Otherwise it's a lead agent ID — find its projectId
+    // selectedLeadId is always a real agent UUID — find its projectId
     const lead = agents.find((a) => a.id === selectedLeadId);
     return lead?.projectId ?? selectedLeadId;
   }, [selectedLeadId, agents]);
@@ -95,9 +91,6 @@ function _HomeRedirect() {
 
   const projectId = useMemo(() => {
     if (selectedLeadId) {
-      if (selectedLeadId.startsWith('project:')) {
-        return selectedLeadId.slice('project:'.length);
-      }
       const lead = agents.find((a) => a.id === selectedLeadId);
       return lead?.projectId ?? selectedLeadId;
     }
@@ -287,16 +280,8 @@ function AppContent() {
     queryFn: async ({ signal }) => {
       const projects: Project[] = await apiFetch('/projects', { signal });
       if (!Array.isArray(projects)) return [];
-      const store = useLeadStore.getState();
-      for (const proj of projects) {
-        if (proj.status === 'archived') continue;
-        const key = `project:${proj.id}`;
-        store.addProject(key);
-      }
-      if (!store.selectedLeadId && projects.length > 0) {
-        const first = projects.find((p) => p.status !== 'archived');
-        if (first) store.selectLead(`project:${first.id}`);
-      }
+      // Projects are discovered via ProjectLayout when the user navigates.
+      // No need to pre-populate leadStore with project:xxx keys.
       return projects;
     },
     staleTime: 30_000,

--- a/packages/web/src/__tests__/App.coverage.test.tsx
+++ b/packages/web/src/__tests__/App.coverage.test.tsx
@@ -465,9 +465,13 @@ describe('AppCoverage', () => {
       });
     });
 
-    it('resolves selectedLeadId with project: prefix', async () => {
-      useLeadStore.setState({ selectedLeadId: 'project:proj-123' });
-      useAppStore.setState({ agents: [] });
+    it('resolves selectedLeadId as agent ID to projectId', async () => {
+      useAppStore.setState({
+        agents: [
+          { id: 'lead-123', role: { id: 'lead', name: 'Lead', icon: '👑' }, status: 'running', parentId: undefined, projectId: 'proj-123' },
+        ] as any,
+      });
+      useLeadStore.setState({ selectedLeadId: 'lead-123' });
 
       renderApp('/tasks');
       await waitFor(() => {
@@ -475,7 +479,7 @@ describe('AppCoverage', () => {
       });
     });
 
-    it('resolves selectedLeadId as agent ID to projectId', async () => {
+    it('resolves selectedLeadId as agent ID to projectId for overview', async () => {
       useAppStore.setState({
         agents: [
           { id: 'lead-sel', role: { id: 'lead', name: 'Lead', icon: '👑' }, status: 'running', parentId: undefined, projectId: 'proj-from-agent' },

--- a/packages/web/src/__tests__/AppRoutes.test.tsx
+++ b/packages/web/src/__tests__/AppRoutes.test.tsx
@@ -366,12 +366,19 @@ describe('AppRoutes – ProjectRedirect behavior', () => {
   });
 
   it('/lead with a selected lead ID redirects to project session', async () => {
-    mockSelectedLeadId = 'project:proj-42';
+    mockSelectedLeadId = 'lead-agent-42';
+    useAppStore.setState({
+      agents: [
+        { id: 'lead-agent-42', role: { id: 'lead' }, parentId: undefined, status: 'running', projectId: 'proj-42' },
+      ] as any,
+      selectedAgentId: null,
+      systemPaused: false,
+      connected: true,
+      loading: false,
+    });
 
     renderApp('/lead');
     await waitFor(() => {
-      // ProjectRedirect extracts "proj-42" from "project:proj-42"
-      // and redirects to /projects/proj-42/session
       expect(screen.getByTestId('project-layout')).toBeInTheDocument();
       expect(screen.getByTestId('mock-LeadDashboard')).toBeInTheDocument();
     });
@@ -400,7 +407,16 @@ describe('AppRoutes – ProjectRedirect behavior', () => {
   });
 
   it('/overview redirects using ProjectRedirect', async () => {
-    mockSelectedLeadId = 'project:my-proj';
+    mockSelectedLeadId = 'lead-my-proj';
+    useAppStore.setState({
+      agents: [
+        { id: 'lead-my-proj', role: { id: 'lead' }, parentId: undefined, status: 'running', projectId: 'my-proj' },
+      ] as any,
+      selectedAgentId: null,
+      systemPaused: false,
+      connected: true,
+      loading: false,
+    });
 
     renderApp('/overview');
     await waitFor(() => {
@@ -409,7 +425,16 @@ describe('AppRoutes – ProjectRedirect behavior', () => {
   });
 
   it('/tasks redirects to project tasks via ProjectRedirect', async () => {
-    mockSelectedLeadId = 'project:proj-1';
+    mockSelectedLeadId = 'lead-proj-1';
+    useAppStore.setState({
+      agents: [
+        { id: 'lead-proj-1', role: { id: 'lead' }, parentId: undefined, status: 'running', projectId: 'proj-1' },
+      ] as any,
+      selectedAgentId: null,
+      systemPaused: false,
+      connected: true,
+      loading: false,
+    });
 
     renderApp('/tasks');
     await waitFor(() => {

--- a/packages/web/src/components/ChatPanel/AcpOutput.tsx
+++ b/packages/web/src/components/ChatPanel/AcpOutput.tsx
@@ -176,27 +176,33 @@ export function AcpOutput({ agentId }: Props) {
   const plan = agent?.plan ?? [];
   const messages = agent?.messages ?? [];
 
-  // Fetch message history when agent panel opens and no messages are loaded yet
+  // Fetch message history when agent panel opens — always merge with live WS messages
+  const historyFetchedRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!agentId || messages.length > 0) return;
+    if (!agentId || historyFetchedRef.current === agentId) return;
+    historyFetchedRef.current = agentId;
     apiFetch<{ messages: Array<{ sender?: string; content?: string; text?: string; timestamp?: number }> }>(`/agents/${agentId}/messages?limit=200`)
       .then((data) => {
         if (Array.isArray(data.messages) && data.messages.length > 0) {
+          const msgs: AcpTextChunk[] = data.messages.map((m) => ({
+            type: 'text' as const,
+            text: m.content || m.text || '',
+            sender: (m.sender || 'agent') as 'agent' | 'user' | 'system' | 'thinking',
+            timestamp: m.timestamp ? new Date(m.timestamp).getTime() : Date.now(),
+          }));
           const existing = useAppStore.getState().agents.find((a) => a.id === agentId);
-          // Only load if still no messages (avoid overwriting live data)
           if (!existing?.messages?.length) {
-            const msgs: AcpTextChunk[] = data.messages.map((m) => ({
-              type: 'text' as const,
-              text: m.content || m.text || '',
-              sender: (m.sender || 'agent') as 'agent' | 'user' | 'system' | 'thinking',
-              timestamp: m.timestamp ? new Date(m.timestamp).getTime() : Date.now(),
-            }));
             useAppStore.getState().updateAgent(agentId, { messages: msgs });
+          } else {
+            // Merge: DB history first, then any live WS messages newer than the latest historical
+            const latestHistTs = Math.max(...msgs.map((m) => m.timestamp ?? 0));
+            const liveOnly = existing.messages.filter((m) => (m.timestamp ?? 0) > latestHistTs);
+            useAppStore.getState().updateAgent(agentId, { messages: [...msgs, ...liveOnly] });
           }
         }
       })
       .catch(() => { /* data will load on next poll */ });
-  }, [agentId, messages.length]);
+  }, [agentId]);
 
   // Get activity events for this agent from leadStore
   const allProjects = useLeadStore((s) => s.projects);

--- a/packages/web/src/components/ChatPanel/__tests__/AcpOutput.test.tsx
+++ b/packages/web/src/components/ChatPanel/__tests__/AcpOutput.test.tsx
@@ -301,10 +301,13 @@ describe('AcpOutput', () => {
     );
   });
 
-  it('does NOT call apiFetch when messages already exist', async () => {
+  it('fetches history even when messages already exist (merge behavior)', async () => {
     seedAgent([makeMsg('Already here', 'agent', 1000)]);
     await renderAcpOutput();
-    expect(mockApiFetch).not.toHaveBeenCalled();
+    // With the always-fetch-and-merge behavior, apiFetch IS called to load DB history
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/agents/'),
+    );
   });
 
   /* ---------- System message filtering ---------- */

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -125,7 +125,7 @@ function buildActionItems(
       keywords: ['export', 'save', 'download', 'session'],
       action: async () => {
         const leadId = useLeadStore.getState().selectedLeadId;
-        if (!leadId || leadId.startsWith('project:')) {
+        if (!leadId) {
           alert('Select an active project first');
           onClose();
           return;

--- a/packages/web/src/components/LeadDashboard/LeadDashboard.tsx
+++ b/packages/web/src/components/LeadDashboard/LeadDashboard.tsx
@@ -52,23 +52,11 @@ export function LeadDashboard({ readOnly = false }: Props) {
   );
   const agents = useAppStore((s) => s.agents);
   const connected = useAppStore((s) => s.connected);
-  // Resolve project ID for historical agent derivation:
-  // - "project:xxx" → strip prefix to get the project UUID
-  // - Live lead UUID → use the lead's projectId, or the lead UUID itself as fallback
+  // Derive project ID from the selected lead agent
   const historicalProjectId = useMemo(() => {
     if (!selectedLeadId) return null;
-    if (selectedLeadId.startsWith('project:')) return selectedLeadId.slice(8);
     const lead = agents.find((a) => a.id === selectedLeadId);
     return lead?.projectId ?? selectedLeadId;
-  }, [selectedLeadId, agents]);
-
-  // Resolve 'project:xxx' selectedLeadId to the actual active lead agent ID
-  const effectiveLeadId = useMemo(() => {
-    if (!selectedLeadId?.startsWith('project:')) return selectedLeadId;
-    const projectId = selectedLeadId.slice(8);
-    return agents.find(
-      (a) => a.projectId === projectId && a.role?.id === 'lead' && a.status !== 'terminated',
-    )?.id ?? selectedLeadId;
   }, [selectedLeadId, agents]);
 
   const { agents: derivedAgents } = useHistoricalAgents(agents.length, historicalProjectId, connected);
@@ -130,12 +118,12 @@ export function LeadDashboard({ readOnly = false }: Props) {
   const leadAgent = agents.find((a) => a.id === selectedLeadId);
   const isActive = leadAgent && (leadAgent.status === 'running' || leadAgent.status === 'idle');
 
-  const { catchUpSummary, dismissCatchUp } = useCatchUpSummary(selectedLeadId, effectiveLeadId, agents, currentProject);
+  const { catchUpSummary, dismissCatchUp } = useCatchUpSummary(selectedLeadId, selectedLeadId, agents, currentProject);
 
   const chatInitialScroll = useRef(false);
   useLeadMessages(selectedLeadId, readOnly, ws, chatInitialScroll);
 
-  const isActiveAgent = selectedLeadId != null && !selectedLeadId.startsWith('project:') && !readOnly && isActive === true;
+  const isActiveAgent = selectedLeadId != null && !readOnly && isActive === true;
   useLeadPolling(selectedLeadId, isActiveAgent, historicalProjectId);
 
   // Auto-scroll on new messages
@@ -224,7 +212,7 @@ export function LeadDashboard({ readOnly = false }: Props) {
   const groupMessages = currentProject?.groupMessages ?? EMPTY_GROUP_MESSAGES;
   const dagStatus = currentProject?.dagStatus ?? null;
   const teamAgents = (() => {
-    const live = agents.filter((a) => a.id === effectiveLeadId || a.parentId === effectiveLeadId);
+    const live = agents.filter((a) => a.id === selectedLeadId || a.parentId === selectedLeadId);
     if (live.length > 0) return live;
     // Fallback: progress endpoint, then keyframe-derived agents
     const progressTeam = progress?.crewAgents ?? EMPTY_CREW_AGENTS;

--- a/packages/web/src/components/LeadDashboard/SidebarTabs.tsx
+++ b/packages/web/src/components/LeadDashboard/SidebarTabs.tsx
@@ -254,7 +254,7 @@ export function SidebarTabs({
             {tabs.activeTab === 'crew' && crewTabContent}
             {tabs.activeTab === 'comms' && <CommsPanelContent comms={comms} groupMessages={groupMessages} leadId={selectedLeadId ?? undefined} />}
 
-            {tabs.activeTab === 'groups' && <GroupsPanelContent groups={groups} groupMessages={groupMessages} leadId={selectedLeadId} projectId={leadAgent?.projectId ?? (selectedLeadId?.startsWith('project:') ? selectedLeadId.slice(8) : null)} />}
+            {tabs.activeTab === 'groups' && <GroupsPanelContent groups={groups} groupMessages={groupMessages} leadId={selectedLeadId} projectId={leadAgent?.projectId ?? null} />}
             {tabs.activeTab === 'dag' && <TaskDagPanelContent dagStatus={dagStatus} />}
             {tabs.activeTab === 'models' && leadAgent?.projectId && (
               <div className="h-full overflow-y-auto p-2">

--- a/packages/web/src/components/LeadDashboard/__tests__/SidebarTabs.extra.test.tsx
+++ b/packages/web/src/components/LeadDashboard/__tests__/SidebarTabs.extra.test.tsx
@@ -187,10 +187,10 @@ describe('SidebarTabs — extra coverage', () => {
       expect(screen.getByTestId('groups-panel')).toBeTruthy();
     });
 
-    it('groups tab handles project: prefix in selectedLeadId', () => {
+    it('groups tab handles null leadAgent gracefully', () => {
       const props = makeProps();
       props.tabs.activeTab = 'groups';
-      props.selectedLeadId = 'project:abc123';
+      props.selectedLeadId = 'lead-abc123';
       props.leadAgent = undefined;
       render(<SidebarTabs {...props} />);
       expect(screen.getByTestId('groups-panel')).toBeTruthy();

--- a/packages/web/src/components/LeadDashboard/__tests__/useLeadMessages.test.ts
+++ b/packages/web/src/components/LeadDashboard/__tests__/useLeadMessages.test.ts
@@ -196,47 +196,54 @@ describe('useLeadMessages', () => {
     expect(mockSetMessages).toHaveBeenCalled();
   });
 
-  it('uses project API path for historical leads', async () => {
+  it('always uses agent API path (no project:xxx routing)', async () => {
     mockApiFetch.mockImplementation((path: string) => {
-      if (path.includes('/projects/')) {
-        return Promise.resolve({ messages: [] });
+      if (path.includes('/agents/')) {
+        return Promise.resolve({ messages: [{ sender: 'agent', content: 'historical', timestamp: '2024-01-01T00:00:00Z' }] });
       }
       return Promise.resolve([]);
     });
 
     renderHook(
-      () => useLeadMessages('project:abc-123', false, makeWs(), makeScrollRef()),
+      () => useLeadMessages('lead-uuid-1', false, makeWs(), makeScrollRef()),
       { wrapper: createWrapper() },
     );
 
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/projects/abc-123/messages'),
+        expect.stringContaining('/agents/lead-uuid-1/messages'),
         expect.anything(),
       );
     });
   });
 
-  it('does not reload messages when store already has them', async () => {
+  it('fetches history even when store already has messages (always merge)', async () => {
     mockProjects = {
-      'lead-1': { messages: [{ type: 'text', text: 'existing', sender: 'agent', timestamp: 123 }] },
+      'lead-1': { messages: [{ type: 'text', text: 'live', sender: 'agent', timestamp: 2000 }] },
     };
+
+    mockApiFetch.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.includes('/agents/lead-1/messages')) {
+        return Promise.resolve({
+          messages: [{ sender: 'agent', content: 'historical', timestamp: '1970-01-01T00:00:01Z' }],
+        });
+      }
+      if (path === '/lead') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
 
     renderHook(
       () => useLeadMessages('lead-1', false, makeWs(), makeScrollRef()),
       { wrapper: createWrapper() },
     );
 
-    // Give queries a chance to fire
-    await act(async () => {
-      await new Promise(r => setTimeout(r, 50));
+    // The query should fire even though store has messages (enabled: !!selectedLeadId)
+    await waitFor(() => {
+      const msgCalls = mockApiFetch.mock.calls.filter(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('/agents/lead-1/messages'),
+      );
+      expect(msgCalls.length).toBeGreaterThan(0);
     });
-
-    // The message history query should not have fired since store has messages
-    const msgCalls = mockApiFetch.mock.calls.filter(
-      (c: any[]) => typeof c[0] === 'string' && c[0].includes('/agents/lead-1/messages'),
-    );
-    expect(msgCalls).toHaveLength(0);
   });
 
   it('handles non-array leads response gracefully', async () => {

--- a/packages/web/src/components/LeadDashboard/__tests__/useLeadWebSocket.test.ts
+++ b/packages/web/src/components/LeadDashboard/__tests__/useLeadWebSocket.test.ts
@@ -320,74 +320,39 @@ describe('useLeadWebSocket', () => {
     expect(mockStore.addActivity).not.toHaveBeenCalled();
   });
 
-  // ── project:xxx resolution tests ──────────────────────────────
+  // ── direct UUID matching tests (project:xxx pattern removed) ──
 
-  describe('project:xxx selectedLeadId resolution', () => {
-    const projAgents: AgentInfo[] = [
+  describe('direct UUID matching (no project:xxx resolution)', () => {
+    const agents: AgentInfo[] = [
       { id: 'agent-uuid-1', status: 'running', projectId: 'proj-1', role: { id: 'lead', name: 'Lead' } } as AgentInfo,
       { id: 'child-2', status: 'running', parentId: 'agent-uuid-1', role: { id: 'developer', name: 'Developer' } } as AgentInfo,
     ];
 
     beforeEach(() => {
-      mockStore.selectedLeadId = 'project:proj-1';
-      (mockStore as Record<string, unknown>).projects = { 'project:proj-1': {} };
+      mockStore.selectedLeadId = 'agent-uuid-1';
+      (mockStore as Record<string, unknown>).projects = { 'agent-uuid-1': {} };
     });
 
-    it('resolves project:xxx to lead agentId for agent:text', () => {
-      renderHook(() => useLeadWebSocket(projAgents, 'proj-1'));
+    it('matches agent:text by direct UUID', () => {
+      renderHook(() => useLeadWebSocket(agents, 'proj-1'));
       emitWsMessage({ type: 'agent:text', agentId: 'agent-uuid-1', text: 'hello' });
-      expect(mockStore.appendToLastAgentMessage).toHaveBeenCalledWith('project:proj-1', 'hello');
+      expect(mockStore.appendToLastAgentMessage).toHaveBeenCalledWith('agent-uuid-1', 'hello');
     });
 
-    it('resolves project:xxx to lead agentId for agent:thinking', () => {
-      renderHook(() => useLeadWebSocket(projAgents, 'proj-1'));
+    it('matches agent:thinking by direct UUID', () => {
+      renderHook(() => useLeadWebSocket(agents, 'proj-1'));
       emitWsMessage({ type: 'agent:thinking', agentId: 'agent-uuid-1', text: 'pondering' });
-      expect(mockStore.appendToThinkingMessage).toHaveBeenCalledWith('project:proj-1', 'pondering');
+      expect(mockStore.appendToThinkingMessage).toHaveBeenCalledWith('agent-uuid-1', 'pondering');
     });
 
-    it('resolves project:xxx to lead agentId for agent:content', () => {
-      renderHook(() => useLeadWebSocket(projAgents, 'proj-1'));
-      emitWsMessage({
-        type: 'agent:content',
-        agentId: 'agent-uuid-1',
-        content: { text: 'content text', contentType: 'text' },
-      });
-      expect(mockStore.addMessage).toHaveBeenCalledWith(
-        'project:proj-1',
-        expect.objectContaining({ text: 'content text', sender: 'agent' }),
-      );
-    });
-
-    it('resolves project:xxx to lead agentId for agent:status running', () => {
-      renderHook(() => useLeadWebSocket(projAgents, 'proj-1'));
-      emitWsMessage({ type: 'agent:status', agentId: 'agent-uuid-1', status: 'running' });
-      expect(mockStore.promoteQueuedMessages).toHaveBeenCalledWith('project:proj-1');
-    });
-
-    it('resolves project:xxx to lead agentId for agent:tool_call', () => {
-      renderHook(() => useLeadWebSocket(projAgents, 'proj-1'));
-      emitWsMessage({
-        type: 'agent:tool_call',
-        agentId: 'agent-uuid-1',
-        toolCall: { toolCallId: 'tc-resolve', title: 'running tool' },
-      });
-      expect(mockStore.addActivity).toHaveBeenCalledWith(
-        'agent-uuid-1',
-        expect.objectContaining({ agentId: 'agent-uuid-1', type: 'tool_call' }),
-      );
-    });
-
-    it('does not resolve when no matching lead agent exists', () => {
-      const noLeadAgents: AgentInfo[] = [
-        { id: 'child-only', status: 'running', projectId: 'other-proj', role: { id: 'developer', name: 'Developer' } } as AgentInfo,
-      ];
-      renderHook(() => useLeadWebSocket(noLeadAgents, 'proj-1'));
-      emitWsMessage({ type: 'agent:text', agentId: 'agent-uuid-1', text: 'should not match' });
+    it('ignores messages from non-lead agents', () => {
+      renderHook(() => useLeadWebSocket(agents, 'proj-1'));
+      emitWsMessage({ type: 'agent:text', agentId: 'child-2', text: 'not lead' });
       expect(mockStore.appendToLastAgentMessage).not.toHaveBeenCalled();
     });
 
-    it('resolves project:xxx for group:message events', () => {
-      renderHook(() => useLeadWebSocket(projAgents, 'proj-1'));
+    it('matches group:message by leadId', () => {
+      renderHook(() => useLeadWebSocket(agents, 'proj-1'));
       emitWsMessage({
         type: 'group:message',
         leadId: 'agent-uuid-1',
@@ -395,7 +360,7 @@ describe('useLeadWebSocket', () => {
         message: { fromAgentId: 'child-2', fromRole: 'Developer', content: 'group msg' },
       });
       expect(mockStore.addGroupMessage).toHaveBeenCalledWith(
-        'project:proj-1',
+        'agent-uuid-1',
         'grp-1',
         expect.objectContaining({ fromAgentId: 'child-2' }),
       );

--- a/packages/web/src/components/LeadDashboard/useCatchUpSummary.ts
+++ b/packages/web/src/components/LeadDashboard/useCatchUpSummary.ts
@@ -9,7 +9,7 @@ const EMPTY_REPORTS: AgentReport[] = [];
 
 export function useCatchUpSummary(
   selectedLeadId: string | null,
-  effectiveLeadId: string | null | undefined,
+  _effectiveLeadId: string | null | undefined,
   agents: Array<{ id: string; parentId?: string; status: string }>,
   currentProject: { decisions?: Decision[]; comms?: AgentComm[]; agentReports?: AgentReport[] } | null,
 ) {
@@ -41,7 +41,7 @@ export function useCatchUpSummary(
   useEffect(() => {
     if (!currentProject) return;
     const currentCounts = {
-      tasks: agents.filter(a => a.parentId === effectiveLeadId && (a.status === 'completed' || a.status === 'failed')).length,
+      tasks: agents.filter(a => a.parentId === selectedLeadId && (a.status === 'completed' || a.status === 'failed')).length,
       decisions: (currentProject.decisions ?? EMPTY_DECISIONS).filter((d: Decision) => d.needsConfirmation && d.status === 'recorded').length,
       comms: (currentProject.comms ?? EMPTY_COMMS).length,
       reports: (currentProject.agentReports ?? EMPTY_REPORTS).length,

--- a/packages/web/src/components/LeadDashboard/useLeadMessages.ts
+++ b/packages/web/src/components/LeadDashboard/useLeadMessages.ts
@@ -83,14 +83,10 @@ export function useLeadMessages(
     };
   }, [selectedLeadId, ws, readOnly, chatInitialScroll]);
 
-  // Load message history for selected lead (if store is empty)
+  // Load message history for selected lead — always fetch + merge with live WS messages
   const selectedProj = selectedLeadId ? projects[selectedLeadId] : null;
-  const needsHistory = !!selectedLeadId && (!selectedProj || selectedProj.messages.length === 0);
-  const isHistorical = selectedLeadId?.startsWith('project:') ?? false;
   const msgApiPath = selectedLeadId
-    ? isHistorical
-      ? `/projects/${selectedLeadId.slice(8)}/messages?limit=200`
-      : `/agents/${selectedLeadId}/messages?limit=200&includeSystem=true`
+    ? `/agents/${selectedLeadId}/messages?limit=200&includeSystem=true`
     : '';
 
   useQuery({
@@ -108,11 +104,16 @@ export function useLeadMessages(
         const current = useLeadStore.getState().projects[selectedLeadId!];
         if (!current || current.messages.length === 0) {
           useLeadStore.getState().setMessages(selectedLeadId!, msgs);
+        } else {
+          // Merge: DB history first, then any live WS messages newer than the latest historical
+          const latestHistTs = Math.max(...msgs.map((m) => m.timestamp ?? 0));
+          const liveOnly = current.messages.filter((m) => (m.timestamp ?? 0) > latestHistTs);
+          useLeadStore.getState().setMessages(selectedLeadId!, [...msgs, ...liveOnly]);
         }
       }
       return data;
     },
-    enabled: needsHistory,
+    enabled: !!selectedLeadId,
     staleTime: 60_000,
   });
 }

--- a/packages/web/src/components/LeadDashboard/useLeadWebSocket.ts
+++ b/packages/web/src/components/LeadDashboard/useLeadWebSocket.ts
@@ -405,37 +405,26 @@ export function useLeadWebSocket(agents: AgentInfo[], historicalProjectId: strin
     const handler = (event: Event) => {
       const msg: WsMsg = JSON.parse((event as MessageEvent).data);
       const store = useLeadStore.getState();
-      const selectedLeadId = store.selectedLeadId;
-
-      // Resolve project:xxx keys to the actual agent UUID for message matching.
-      // selectedLeadId may temporarily be "project:<id>" during session resume
-      // (before ProjectLayout resolves the real lead agent). Messages arrive with
-      // the real agent UUID, so we need to resolve to match them.
-      let effectiveLeadId = selectedLeadId;
-      if (selectedLeadId?.startsWith('project:') && agents.length > 0) {
-        const projectId = selectedLeadId.slice(8);
-        const lead = agents.find((a) => a.projectId === projectId && a.role?.id === 'lead' && a.status !== 'terminated');
-        if (lead) effectiveLeadId = lead.id;
-      }
+      const leadId = store.selectedLeadId;
 
       switch (msg.type) {
         case 'lead:decision':
           handleDecision(msg, store);
           break;
         case 'agent:text':
-          if (msg.agentId === effectiveLeadId) handleText(msg, store, selectedLeadId!);
+          if (msg.agentId === leadId) handleText(msg, store, leadId!);
           break;
         case 'agent:thinking':
-          if (msg.agentId === effectiveLeadId) handleThinking(msg, store, selectedLeadId!);
+          if (msg.agentId === leadId) handleThinking(msg, store, leadId!);
           break;
         case 'agent:content':
-          if (msg.agentId === effectiveLeadId) handleContent(msg, store, selectedLeadId!);
+          if (msg.agentId === leadId) handleContent(msg, store, leadId!);
           break;
         case 'agent:status':
-          if (msg.agentId === effectiveLeadId) handleStatus(msg, store, selectedLeadId!);
+          if (msg.agentId === leadId) handleStatus(msg, store, leadId!);
           break;
         case 'agent:tool_call':
-          if (effectiveLeadId) handleToolCall(msg, store, agents, effectiveLeadId);
+          if (leadId) handleToolCall(msg, store, agents, leadId);
           break;
         case 'agent:delegated':
           handleDelegation(msg, store, agents);
@@ -447,16 +436,16 @@ export function useLeadWebSocket(agents: AgentInfo[], historicalProjectId: strin
           handleProgress(msg, store);
           break;
         case 'agent:message_sent':
-          if (effectiveLeadId) handleMessageSent(msg, store, agents, effectiveLeadId);
+          if (leadId) handleMessageSent(msg, store, agents, leadId);
           break;
         case 'group:created':
-          if ((msg.leadId === selectedLeadId || msg.leadId === effectiveLeadId) && effectiveLeadId) handleGroupCreated(store, selectedLeadId!);
+          if (msg.leadId === leadId && leadId) handleGroupCreated(store, leadId);
           break;
         case 'group:message':
-          if ((msg.leadId === selectedLeadId || msg.leadId === effectiveLeadId) && effectiveLeadId) handleGroupMessage(msg, store, selectedLeadId!);
+          if (msg.leadId === leadId && leadId) handleGroupMessage(msg, store, leadId);
           break;
         case 'dag:updated':
-          if ((msg.leadId === selectedLeadId || msg.leadId === effectiveLeadId) && effectiveLeadId) handleDagUpdated(store, selectedLeadId!, historicalProjectId);
+          if (msg.leadId === leadId && leadId) handleDagUpdated(store, leadId, historicalProjectId);
           break;
         case 'agent:context_compacted':
           handleContextCompacted(msg, store, agents);

--- a/packages/web/src/layouts/ProjectLayout.tsx
+++ b/packages/web/src/layouts/ProjectLayout.tsx
@@ -165,8 +165,7 @@ export function ProjectLayout() {
     if (!id) return;
     const store = useLeadStore.getState();
 
-    // Find matching leadStore key: either a lead agent ID with this projectId,
-    // or the `project:${id}` key for persisted projects
+    // Find lead agent matching this project's ID
     const lead = agents.find(
       (a) => a.role?.id === 'lead' && !a.parentId && (a.projectId === id || a.id === id),
     );
@@ -177,19 +176,9 @@ export function ProjectLayout() {
       if (store.selectedLeadId !== lead.id) {
         store.selectLead(lead.id);
       }
-    } else {
-      // No live lead yet — fall back to project:xxx ONLY if we don't already
-      // have a real agent ID selected (e.g. set during resume before agent:spawned arrives)
-      const currentKey = store.selectedLeadId;
-      const currentIsRealAgentForProject = currentKey && !currentKey.startsWith('project:');
-      if (!currentIsRealAgentForProject) {
-        const fallbackKey = `project:${id}`;
-        store.addProject(fallbackKey);
-        if (currentKey !== fallbackKey) {
-          store.selectLead(fallbackKey);
-        }
-      }
     }
+    // If no live lead found, do nothing — selectedLeadId stays null
+    // until the lead agent spawns and agents list updates
   }, [id, agents]);
 
   // Sync project context → navigationStore


### PR DESCRIPTION
## Summary

Eliminates the `project:xxx` dual-key identity crisis where `selectedLeadId` could be either a real agent UUID or `project:${projectId}`. This was the #1 finding from the architecture audit.

### Root Cause
The `project:xxx` pattern was a workaround for the gap between page navigation (when only the project ID is known) and agent discovery (when the real lead UUID is available). This created a dual-key system where 8 files had `startsWith('project:')` checks and `.slice(8)` extractions, leading to ID mismatch bugs during session resume.

### What Changed (15 files, net -38 lines)
- **ProjectLayout**: Only sets `selectedLeadId` when a real lead agent is found — no more `project:xxx` fallback
- **App.tsx**: Removed `project:xxx` key creation for persisted projects, removed prefix checks from redirects
- **LeadDashboard**: Removed `effectiveLeadId` resolution memo and `project:` prefix check from `isActiveAgent`
- **useLeadWebSocket**: Removed 16-line `project:xxx → UUID` resolution block — direct UUID matching
- **useLeadMessages**: Always use `/agents/` API (removed `isHistorical` routing to `/projects/` API)
- **useLeadMessages + AcpOutput**: Always fetch + merge DB history with live WS messages (fixes the "skip if store non-empty" guard that prevented historical messages from loading after resume)
- **SidebarTabs, CommandPalette, useCatchUpSummary**: Simplified — derive from agent object, not string prefix

### Bug Fixes Included
The history merge fix resolves the same root cause as PR #173 (lead chat and agent panel messages not loading after resume) — both `useLeadMessages` and `AcpOutput` had guards that skipped DB fetch when the store was non-empty, so live WS messages blocked historical data from ever loading.

### Tests
- All 4324 tests pass (316 test files)
- Updated tests to use real UUIDs instead of `project:xxx` keys
- Zero remaining `project:` pattern occurrences in source or test files