### PR TITLE
fix: render separator system messages as <hr> in Lead Dashboard chat

### DIFF
--- a/packages/web/src/components/LeadDashboard/ChatMessages.tsx
+++ b/packages/web/src/components/LeadDashboard/ChatMessages.tsx
@@ -17,7 +17,7 @@ export interface CatchUpSummary {
 
 // Pre-computed chat item after filtering and merging
 interface ChatItem {
-  kind: 'user' | 'system' | 'system-long' | 'thinking' | 'agent-rich' | 'agent-text' | 'working';
+  kind: 'user' | 'system' | 'system-long' | 'separator' | 'thinking' | 'agent-rich' | 'agent-text' | 'working';
   msg: AcpTextChunk;
   ts: string;
   mergedText?: string;
@@ -43,6 +43,11 @@ function buildChatItems(messages: AcpTextChunk[], isActive: boolean): ChatItem[]
 
     if (msg.sender === 'system') {
       const sysText = typeof msg.text === 'string' ? msg.text : '';
+
+      if (sysText === '---') {
+        items.push({ kind: 'separator', msg, ts, originalIndex: i });
+        continue;
+      }
 
       items.push({ kind: sysText.length > 200 ? 'system-long' : 'system', msg, ts, originalIndex: i });
       continue;
@@ -164,6 +169,10 @@ export function ChatMessages({
 
     if (item.kind === 'system-long') {
       return <CollapsibleSystemBlock text={item.msg.text} timestamp={item.ts} />;
+    }
+
+    if (item.kind === 'separator') {
+      return <div className="border-t border-th-border/50 my-2" />;
     }
 
     if (item.kind === 'system') {

--- a/packages/web/src/components/LeadDashboard/__tests__/ChatMessages.extra.test.tsx
+++ b/packages/web/src/components/LeadDashboard/__tests__/ChatMessages.extra.test.tsx
@@ -452,6 +452,46 @@ describe('ChatMessages – extra coverage', () => {
     expect(container.textContent).not.toContain('Received from agent');
   });
 
+  /* ── Separator system messages ('---') ──────────────────────────── */
+
+  it('renders "---" system messages as separator lines, not pill blobs', () => {
+    const messages: AcpTextChunk[] = [
+      makeMessage({ sender: 'agent', text: 'Before separator' }),
+      makeMessage({ sender: 'system', text: '---' }),
+      makeMessage({ sender: 'agent', text: 'After separator' }),
+    ];
+
+    const { container } = render(
+      <ChatMessages {...defaultProps} messages={messages} />,
+    );
+
+    // The separator should render as a border-t div, not a pill with RefreshCw icon
+    const separators = container.querySelectorAll('.border-t');
+    expect(separators.length).toBe(1);
+
+    // The '---' text should NOT appear as visible text content
+    expect(container.textContent).not.toContain('---');
+
+    // Normal messages should still render
+    expect(container.textContent).toContain('Before separator');
+    expect(container.textContent).toContain('After separator');
+  });
+
+  it('still renders non-separator system messages as pill blobs', () => {
+    const messages: AcpTextChunk[] = [
+      makeMessage({ sender: 'system', text: '🔄 Agent restarted' }),
+    ];
+
+    const { container } = render(
+      <ChatMessages {...defaultProps} messages={messages} />,
+    );
+
+    // Regular system messages should still have the pill styling (rounded-full class)
+    const pills = container.querySelectorAll('.rounded-full');
+    expect(pills.length).toBeGreaterThanOrEqual(1);
+    expect(container.textContent).toContain('Agent restarted');
+  });
+
   /* ── Queued messages filtered ─────────────────────────────────── */
 
   it('filters out queued messages from display', () => {


### PR DESCRIPTION
## Summary

Fixes the empty blob with refresh button but no message content in the Lead Dashboard chat timeline.

## Root Cause

When a user interrupts an agent (or agent status changes), a `'---'` separator system message is injected into the message store. `AcpOutput.tsx` (agent chat panel) correctly renders these as `<hr />`, but `ChatMessages.tsx` (Lead Dashboard) was rendering them as visible pills with a RefreshCw icon and literal `'---'` text — appearing as an empty blob to users.

## Changes

- Added `'separator'` kind to the `ChatItem` type in `ChatMessages.tsx`
- Detection of `'---'` system messages in `buildChatItems()` assigns the new separator kind
- Separator items render as a horizontal rule (`border-t` div) matching the `AgentChatPanel` pattern
- Added 2 tests covering separator detection and rendering

## Review

Triple-reviewed and approved by:
- **Code Reviewer**: Correct, well-tested, matches AgentChatPanel pattern ✅
- **Critical Reviewer**: Right approach (explicit kind vs filtering), robust detection, zero performance impact ✅
- **Readability Reviewer**: Clean naming, consistent with existing patterns ✅

Non-blocking suggestion: add a comment explaining what generates `'---'` messages (pre-existing magic string pattern across 5 files).