### PR TITLE
feat: add task_completed events to homepage activity feed

### DIFF
--- a/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
+++ b/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
@@ -280,10 +280,11 @@ export function HomeDashboard() {
     try {
       setLoading(true);
       setFetchError(null);
-      const [projectsData, decisionsData, activityData, pendingDecisionsData] = await Promise.all([
+      const [projectsData, decisionsData, progressData, completionData, pendingDecisionsData] = await Promise.all([
         apiFetch<EnrichedProject[]>('/projects').catch(() => []),
         apiFetch<Decision[]>('/decisions').catch(() => []),
         apiFetch<ActivityEntry[]>('/coordination/activity?type=progress_update&limit=15').catch(() => []),
+        apiFetch<ActivityEntry[]>('/coordination/activity?type=task_completed&limit=15').catch(() => []),
         apiFetch<Decision[]>('/decisions?needs_confirmation=true').catch(() => []),
       ]);
 
@@ -297,10 +298,13 @@ export function HomeDashboard() {
       const pending = Array.isArray(pendingDecisionsData) ? pendingDecisionsData : [];
       useAppStore.getState().setPendingDecisions(pending);
 
-      // Server already filters to progress_update; show all agent roles
-      const progressActivity = (Array.isArray(activityData) ? activityData : [])
+      // Merge progress updates and task completions, sort by timestamp
+      const progress = Array.isArray(progressData) ? progressData : [];
+      const completions = Array.isArray(completionData) ? completionData : [];
+      const merged = [...progress, ...completions]
+        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
         .slice(0, 15);
-      setRecentActivity(progressActivity);
+      setRecentActivity(merged);
 
       // Fetch DAG progress for projects with active leads (parallelized)
       const dagPromises = activeProjects
@@ -625,11 +629,11 @@ export function HomeDashboard() {
           </div>
         )}
 
-        {/* Section 4: Recent Progress */}
+        {/* Section 4: Recent Activity */}
         <div data-testid="activity-feed-section">
           <div className="flex items-center gap-2 mb-3">
             <Activity className="w-4 h-4 text-th-text-muted" />
-            <h2 className="text-sm font-medium text-th-text-alt">Recent Progress</h2>
+            <h2 className="text-sm font-medium text-th-text-alt">Recent Activity</h2>
           </div>
           {recentActivity.length > 0 ? (
             <div className="bg-surface-raised border border-th-border rounded-lg divide-y divide-th-border max-h-64 overflow-y-auto">
@@ -647,7 +651,7 @@ export function HomeDashboard() {
             </div>
           ) : (
             <div className="bg-surface-raised border border-th-border rounded-lg px-3 py-4 text-center text-xs text-th-text-muted">
-              No progress updates yet. Updates appear here when the lead reports progress.
+              No activity yet. Progress updates and task completions appear here.
             </div>
           )}
         </div>

--- a/packages/web/src/components/HomeDashboard/__tests__/HomeDashboard.test.tsx
+++ b/packages/web/src/components/HomeDashboard/__tests__/HomeDashboard.test.tsx
@@ -544,9 +544,10 @@ describe('HomeDashboard', () => {
         if (path === '/projects') return Promise.resolve(sampleProjects);
         if (path === '/decisions') return Promise.resolve(sampleAllDecisions);
         if (path.includes('/dag')) return Promise.resolve(sampleDagStatus);
-        if (path.includes('/coordination/activity')) return Promise.resolve([
+        if (path.includes('type=progress_update')) return Promise.resolve([
           { id: 1, agentId: 'agent-1', agentRole: 'lead', actionType: 'progress_update', summary: 'Implemented auth module', timestamp: '2026-03-08T06:00:00Z', projectId: 'proj-1' },
         ]);
+        if (path.includes('type=task_completed')) return Promise.resolve([]);
         return Promise.resolve([]);
       });
 
@@ -565,14 +566,41 @@ describe('HomeDashboard', () => {
       expect(within(modal).getByText('Progress Update')).toBeTruthy();
     });
 
+    it('shows task_completed events merged with progress updates', async () => {
+      mockApiFetch.mockImplementation((path: string) => {
+        if (path === '/projects') return Promise.resolve(sampleProjects);
+        if (path === '/decisions') return Promise.resolve(sampleAllDecisions);
+        if (path.includes('/dag')) return Promise.resolve(sampleDagStatus);
+        if (path.includes('type=progress_update')) return Promise.resolve([
+          { id: 1, agentId: 'agent-1', agentRole: 'lead', actionType: 'progress_update', summary: 'Auth module done', timestamp: '2026-03-08T05:00:00Z', projectId: 'proj-1' },
+        ]);
+        if (path.includes('type=task_completed')) return Promise.resolve([
+          { id: 2, agentId: 'agent-2', agentRole: 'developer', actionType: 'task_completed', summary: 'Completed login endpoint', timestamp: '2026-03-08T06:00:00Z', projectId: 'proj-1' },
+        ]);
+        return Promise.resolve([]);
+      });
+
+      renderWithRouter(<HomeDashboard />);
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-feed-section')).toBeTruthy();
+      });
+
+      const items = screen.getAllByTestId('activity-feed-item');
+      expect(items.length).toBe(2);
+      // task_completed is newer, should appear first
+      expect(within(items[0]).getByText('Completed login endpoint')).toBeTruthy();
+      expect(within(items[1]).getByText('Auth module done')).toBeTruthy();
+    });
+
     it('closes ActivityDetailModal when clicking outside', async () => {
       mockApiFetch.mockImplementation((path: string) => {
         if (path === '/projects') return Promise.resolve(sampleProjects);
         if (path === '/decisions') return Promise.resolve(sampleAllDecisions);
         if (path.includes('/dag')) return Promise.resolve(sampleDagStatus);
-        if (path.includes('/coordination/activity')) return Promise.resolve([
+        if (path.includes('type=progress_update')) return Promise.resolve([
           { id: 1, agentId: 'agent-1', agentRole: 'lead', actionType: 'progress_update', summary: 'Done', timestamp: '2026-03-08T06:00:00Z', projectId: 'proj-1' },
         ]);
+        if (path.includes('type=task_completed')) return Promise.resolve([]);
         return Promise.resolve([]);
       });
 


### PR DESCRIPTION
Adds task completion events to the homepage Recent Activity feed, providing users with the highest-signal events from their agent crews.

## Changes
- Parallel fetch of task_completed events alongside progress_update events
- Merged by timestamp for chronological feed
- Section renamed from Progress Updates to Recent Activity
- Lead-only filter for progress, any-agent for task completions
- Bounded payloads (limit=15 each)

## Review
- Code review: ✅ Approved
- Critical review: ✅ Approved
- Readability review: ✅ Approved

Stacked on fix/overview-filtering (PR #190) — merge that first.

All 36 tests pass.