### PR TITLE
feat: session replay timeline swim lanes (Phase C)

### DIFF
--- a/packages/web/src/components/SessionReplay/ReplayContent.tsx
+++ b/packages/web/src/components/SessionReplay/ReplayContent.tsx
@@ -1,0 +1,286 @@
+import { Users, CheckCircle2, Clock, AlertTriangle, FileText, Activity } from 'lucide-react';
+import type {
+  ReplayWorldState,
+  ReplayAgentState,
+  ReplayDagTask,
+  ReplayDecision,
+  ReplayActivityEntry,
+} from '../../hooks/useSessionReplay';
+import { formatRelativeTime } from '../../utils/formatRelativeTime';
+
+// ── Status colors ────────────────────────────────────────────────────
+
+const AGENT_STATUS_COLORS: Record<string, string> = {
+  running: 'bg-green-400',
+  idle: 'bg-yellow-400',
+  completed: 'bg-blue-400',
+  failed: 'bg-red-400',
+  terminated: 'bg-gray-400',
+};
+
+const TASK_STATUS_ICONS: Record<string, string> = {
+  done: '✅',
+  running: '🔄',
+  ready: '🟢',
+  pending: '⏳',
+  failed: '❌',
+  blocked: '🚫',
+  paused: '⏸️',
+  skipped: '⏭️',
+};
+
+const ACTIVITY_ICONS: Record<string, string> = {
+  progress_update: '📊',
+  task_completed: '✅',
+  task_started: '▶️',
+  decision_made: '⚖️',
+  delegated: '📋',
+  sub_agent_spawned: '🤖',
+  file_edit: '📝',
+  error: '🔴',
+  agent_terminated: '💀',
+  commit: '📦',
+};
+
+// ── Sub-components ───────────────────────────────────────────────────
+
+function AgentRosterPanel({ agents }: { agents: ReplayAgentState[] }) {
+  if (agents.length === 0) {
+    return (
+      <div className="text-xs text-th-text-muted text-center py-4">
+        No agents at this point in time
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-1.5">
+      {agents.map((agent) => (
+        <div
+          key={agent.id}
+          className="flex items-center gap-2 px-2 py-1.5 rounded bg-th-bg-alt/50"
+          data-testid="replay-agent"
+        >
+          <span
+            className={`w-2 h-2 rounded-full shrink-0 ${AGENT_STATUS_COLORS[agent.status] ?? 'bg-gray-400'}`}
+          />
+          <span className="text-xs font-medium text-th-text-alt truncate flex-1">
+            {agent.role}
+          </span>
+          <span className="text-[10px] text-th-text-muted font-mono">
+            {agent.id.slice(0, 8)}
+          </span>
+          {agent.contextUsedPct != null && (
+            <div className="w-12 h-1 bg-th-bg-alt rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full ${agent.contextUsedPct > 80 ? 'bg-red-400' : 'bg-accent/60'}`}
+                style={{ width: `${Math.min(100, agent.contextUsedPct)}%` }}
+              />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TaskDagPanel({ tasks }: { tasks: ReplayDagTask[] }) {
+  if (tasks.length === 0) {
+    return (
+      <div className="text-xs text-th-text-muted text-center py-4">
+        No tasks declared
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-1">
+      {tasks.map((task) => (
+        <div
+          key={task.id}
+          className="flex items-start gap-2 px-2 py-1.5 rounded bg-th-bg-alt/50"
+          data-testid="replay-task"
+        >
+          <span className="text-xs shrink-0 mt-0.5">
+            {TASK_STATUS_ICONS[task.dagStatus] ?? '⏳'}
+          </span>
+          <div className="flex-1 min-w-0">
+            <span className="text-xs text-th-text-alt block truncate">{task.id}</span>
+            {task.description && (
+              <span className="text-[10px] text-th-text-muted block truncate">
+                {task.description}
+              </span>
+            )}
+          </div>
+          {task.assignedTo && (
+            <span className="text-[10px] text-th-text-muted font-mono shrink-0">
+              → {task.assignedTo.slice(0, 8)}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DecisionPanel({ decisions }: { decisions: ReplayDecision[] }) {
+  if (decisions.length === 0) return null;
+  return (
+    <div className="space-y-1">
+      {decisions.map((d) => (
+        <div
+          key={d.id}
+          className="flex items-start gap-2 px-2 py-1.5 rounded bg-th-bg-alt/50"
+          data-testid="replay-decision"
+        >
+          <span className="text-xs shrink-0 mt-0.5">
+            {d.status === 'confirmed' ? '✅' : d.status === 'rejected' ? '❌' : '⚖️'}
+          </span>
+          <div className="flex-1 min-w-0">
+            <span className="text-xs text-th-text-alt block truncate">{d.summary}</span>
+            {d.agentRole && (
+              <span className="text-[10px] text-th-text-muted">by {d.agentRole}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ActivityFeed({ entries }: { entries: ReplayActivityEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <div className="text-xs text-th-text-muted text-center py-4">
+        No activity at this point
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-0.5">
+      {entries.slice(0, 20).map((entry) => (
+        <div
+          key={entry.id}
+          className="flex items-start gap-2 px-2 py-1 text-xs"
+          data-testid="replay-activity"
+        >
+          <span className="shrink-0 mt-0.5">
+            {ACTIVITY_ICONS[entry.actionType] ?? '📎'}
+          </span>
+          <span className="text-th-text-alt truncate flex-1">{entry.summary}</span>
+          <span className="text-[10px] text-th-text-muted shrink-0">
+            {formatRelativeTime(entry.timestamp)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main Component ───────────────────────────────────────────────────
+
+export interface ReplayContentProps {
+  worldState: ReplayWorldState | null;
+  loading?: boolean;
+}
+
+export function ReplayContent({ worldState, loading }: ReplayContentProps) {
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center" data-testid="replay-content-loading">
+        <div className="w-6 h-6 border-2 border-th-text-muted/30 border-t-accent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!worldState) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-center p-8" data-testid="replay-content-empty">
+        <div>
+          <p className="text-3xl mb-2">📼</p>
+          <p className="text-sm text-th-text-muted">Scrub the timeline to see session state</p>
+        </div>
+      </div>
+    );
+  }
+
+  const agents = worldState.agents ?? [];
+  const tasks = worldState.dagTasks ?? [];
+  const decisions = worldState.decisions ?? [];
+  const activity = worldState.recentActivity ?? [];
+  const runningCount = agents.filter(a => a.status === 'running').length;
+
+  return (
+    <div className="flex-1 overflow-hidden" data-testid="replay-content">
+      {/* Summary bar */}
+      <div className="flex items-center gap-4 px-4 py-2 border-b border-th-border text-xs text-th-text-muted">
+        <span className="flex items-center gap-1">
+          <Users className="w-3 h-3" />
+          {agents.length} agents ({runningCount} running)
+        </span>
+        {worldState.totalTasks > 0 && (
+          <span className="flex items-center gap-1">
+            <CheckCircle2 className="w-3 h-3" />
+            {worldState.completedTasks}/{worldState.totalTasks} tasks
+          </span>
+        )}
+        {worldState.pendingDecisions > 0 && (
+          <span className="flex items-center gap-1 text-amber-400">
+            <AlertTriangle className="w-3 h-3" />
+            {worldState.pendingDecisions} pending decisions
+          </span>
+        )}
+        <span className="flex items-center gap-1 ml-auto">
+          <Clock className="w-3 h-3" />
+          {new Date(worldState.timestamp).toLocaleTimeString()}
+        </span>
+      </div>
+
+      {/* 3-column content */}
+      <div className="grid grid-cols-3 gap-0 h-[calc(100%-2.5rem)] overflow-hidden">
+        {/* Left: Agent Roster */}
+        <div className="border-r border-th-border overflow-y-auto p-3">
+          <div className="flex items-center gap-1.5 mb-2">
+            <Users className="w-3.5 h-3.5 text-th-text-muted" />
+            <h3 className="text-xs font-medium text-th-text-alt">Agents</h3>
+          </div>
+          <AgentRosterPanel agents={agents} />
+        </div>
+
+        {/* Center: Activity Feed */}
+        <div className="border-r border-th-border overflow-y-auto p-3">
+          <div className="flex items-center gap-1.5 mb-2">
+            <Activity className="w-3.5 h-3.5 text-th-text-muted" />
+            <h3 className="text-xs font-medium text-th-text-alt">Activity</h3>
+          </div>
+          <ActivityFeed entries={activity} />
+        </div>
+
+        {/* Right: Tasks & Decisions */}
+        <div className="overflow-y-auto p-3">
+          {tasks.length > 0 && (
+            <>
+              <div className="flex items-center gap-1.5 mb-2">
+                <FileText className="w-3.5 h-3.5 text-th-text-muted" />
+                <h3 className="text-xs font-medium text-th-text-alt">Tasks</h3>
+              </div>
+              <TaskDagPanel tasks={tasks} />
+            </>
+          )}
+          {decisions.length > 0 && (
+            <>
+              <div className="flex items-center gap-1.5 mb-2 mt-3">
+                <AlertTriangle className="w-3.5 h-3.5 text-th-text-muted" />
+                <h3 className="text-xs font-medium text-th-text-alt">Decisions</h3>
+              </div>
+              <DecisionPanel decisions={decisions} />
+            </>
+          )}
+          {tasks.length === 0 && decisions.length === 0 && (
+            <div className="text-xs text-th-text-muted text-center py-4">
+              No tasks or decisions at this point
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/SessionReplay/ReplayContent.tsx
+++ b/packages/web/src/components/SessionReplay/ReplayContent.tsx
@@ -110,9 +110,9 @@ function TaskDagPanel({ tasks }: { tasks: ReplayDagTask[] }) {
               </span>
             )}
           </div>
-          {task.assignedTo && (
+          {task.assignedAgentId && (
             <span className="text-[10px] text-th-text-muted font-mono shrink-0">
-              → {task.assignedTo.slice(0, 8)}
+              → {task.assignedAgentId.slice(0, 8)}
             </span>
           )}
         </div>
@@ -135,7 +135,7 @@ function DecisionPanel({ decisions }: { decisions: ReplayDecision[] }) {
             {d.status === 'confirmed' ? '✅' : d.status === 'rejected' ? '❌' : '⚖️'}
           </span>
           <div className="flex-1 min-w-0">
-            <span className="text-xs text-th-text-alt block truncate">{d.summary}</span>
+            <span className="text-xs text-th-text-alt block truncate">{d.title}</span>
             {d.agentRole && (
               <span className="text-[10px] text-th-text-muted">by {d.agentRole}</span>
             )}
@@ -207,6 +207,9 @@ export function ReplayContent({ worldState, loading }: ReplayContentProps) {
   const decisions = worldState.decisions ?? [];
   const activity = worldState.recentActivity ?? [];
   const runningCount = agents.filter(a => a.status === 'running').length;
+  const completedTasks = tasks.filter(t => t.dagStatus === 'done').length;
+  const totalTasks = tasks.length;
+  const pendingDecisions = decisions.filter(d => d.status === 'pending').length;
 
   return (
     <div className="flex-1 overflow-hidden" data-testid="replay-content">
@@ -216,16 +219,16 @@ export function ReplayContent({ worldState, loading }: ReplayContentProps) {
           <Users className="w-3 h-3" />
           {agents.length} agents ({runningCount} running)
         </span>
-        {worldState.totalTasks > 0 && (
+        {totalTasks > 0 && (
           <span className="flex items-center gap-1">
             <CheckCircle2 className="w-3 h-3" />
-            {worldState.completedTasks}/{worldState.totalTasks} tasks
+            {completedTasks}/{totalTasks} tasks
           </span>
         )}
-        {worldState.pendingDecisions > 0 && (
+        {pendingDecisions > 0 && (
           <span className="flex items-center gap-1 text-amber-400">
             <AlertTriangle className="w-3 h-3" />
-            {worldState.pendingDecisions} pending decisions
+            {pendingDecisions} pending decisions
           </span>
         )}
         <span className="flex items-center gap-1 ml-auto">

--- a/packages/web/src/components/SessionReplay/ReplayScrubber.tsx
+++ b/packages/web/src/components/SessionReplay/ReplayScrubber.tsx
@@ -250,16 +250,16 @@ export function ReplayScrubber({ leadId, replay: externalReplay, liveMode, onExi
           <span className="flex items-center gap-1 text-th-text-muted">
             {worldState.agents.filter((a) => a.status === 'running').length} running
           </span>
-          {worldState.totalTasks > 0 && (
+          {(worldState.dagTasks ?? []).length > 0 && (
             <span className="flex items-center gap-1 text-th-text-muted">
               <CheckCircle2 className="w-3 h-3" />
-              {worldState.completedTasks}/{worldState.totalTasks} tasks
+              {(worldState.dagTasks ?? []).filter(t => t.dagStatus === 'done').length}/{(worldState.dagTasks ?? []).length} tasks
             </span>
           )}
-          {worldState.pendingDecisions > 0 && (
+          {(worldState.decisions ?? []).filter(d => d.status === 'pending').length > 0 && (
             <span className="flex items-center gap-1 text-amber-400">
               <AlertTriangle className="w-3 h-3" />
-              {worldState.pendingDecisions} pending
+              {(worldState.decisions ?? []).filter(d => d.status === 'pending').length} pending
             </span>
           )}
         </div>

--- a/packages/web/src/components/SessionReplay/ReplayTimeline.tsx
+++ b/packages/web/src/components/SessionReplay/ReplayTimeline.tsx
@@ -1,0 +1,115 @@
+/**
+ * ReplayTimeline — Lightweight agent swim-lane visualization for session replay.
+ *
+ * Renders one row per agent with a colored bar indicating their active period.
+ * Uses keyframes (spawn/agent_exit) to determine agent lifespans.
+ * Pure CSS — no visx/d3 dependency.
+ */
+import { useMemo } from 'react';
+import type { ReplayKeyframe } from '../../hooks/useSessionReplay';
+import { getRoleIcon } from '../../utils/getRoleIcon';
+
+// ── Role colors (matches Timeline AgentLane palette) ─────────────────
+
+const ROLE_COLORS: Record<string, string> = {
+  lead:       'bg-blue-500/60',
+  architect:  'bg-violet-500/60',
+  developer:  'bg-emerald-500/60',
+  reviewer:   'bg-amber-500/60',
+  secretary:  'bg-cyan-500/60',
+  qa:         'bg-rose-500/60',
+  designer:   'bg-pink-500/60',
+};
+
+const DEFAULT_COLOR = 'bg-gray-400/60';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface AgentSpan {
+  agentId: string;
+  role: string;
+  startPct: number; // 0-100
+  endPct: number;   // 0-100
+}
+
+export interface ReplayTimelineProps {
+  keyframes: ReplayKeyframe[];
+  duration: number;      // total ms
+  currentTime: number;   // ms since start
+  onSeek: (timeMs: number) => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function buildAgentSpans(keyframes: ReplayKeyframe[], duration: number): AgentSpan[] {
+  if (keyframes.length === 0 || duration <= 0) return [];
+
+  const startMs = new Date(keyframes[0].timestamp).getTime();
+  const agents = new Map<string, { role: string; start: number; end: number }>();
+
+  for (const kf of keyframes) {
+    const tMs = new Date(kf.timestamp).getTime() - startMs;
+    const id = kf.agentId;
+    if (!id) continue;
+
+    if (kf.type === 'spawn') {
+      agents.set(id, { role: kf.label.replace(/^Spawned\s+/i, '').split(' ')[0].toLowerCase(), start: tMs, end: duration });
+    } else if (kf.type === 'agent_exit') {
+      const existing = agents.get(id);
+      if (existing) existing.end = tMs;
+    }
+  }
+
+  return Array.from(agents.entries()).map(([agentId, { role, start, end }]) => ({
+    agentId,
+    role,
+    startPct: (start / duration) * 100,
+    endPct: (end / duration) * 100,
+  }));
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export function ReplayTimeline({ keyframes, duration, currentTime, onSeek }: ReplayTimelineProps) {
+  const spans = useMemo(() => buildAgentSpans(keyframes, duration), [keyframes, duration]);
+
+  if (spans.length === 0) return null;
+
+  const progressPct = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const pct = (e.clientX - rect.left) / rect.width;
+    onSeek(pct * duration);
+  };
+
+  return (
+    <div className="border-b border-th-border px-4 py-2" data-testid="replay-timeline">
+      <div className="text-[10px] text-th-text-muted uppercase tracking-wide mb-1">Agent Timeline</div>
+      <div className="space-y-0.5">
+        {spans.map((span) => (
+          <div key={span.agentId} className="flex items-center gap-2 h-5">
+            <span className="text-[10px] text-th-text-muted w-20 truncate text-right shrink-0" title={span.role}>
+              {getRoleIcon(span.role)} {span.role}
+            </span>
+            <div
+              className="flex-1 relative h-3 bg-th-bg-alt/50 rounded-sm overflow-hidden cursor-pointer"
+              onClick={handleClick}
+            >
+              <div
+                className={`absolute top-0 bottom-0 rounded-sm ${ROLE_COLORS[span.role] ?? DEFAULT_COLOR}`}
+                style={{ left: `${span.startPct}%`, width: `${Math.max(span.endPct - span.startPct, 0.5)}%` }}
+                data-testid={`agent-bar-${span.agentId.slice(0, 8)}`}
+              />
+              {/* Playhead */}
+              <div
+                className="absolute top-0 bottom-0 w-px bg-accent pointer-events-none"
+                style={{ left: `${progressPct}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
+++ b/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
@@ -4,6 +4,7 @@ import { Users, Clock, Play, Pause, SkipBack, SkipForward, MapPin } from 'lucide
 import type { ShareableReplay } from './types';
 import { AnnotationPin } from './AnnotationPin';
 import { ReplayContent } from './ReplayContent';
+import { ReplayTimeline } from './ReplayTimeline';
 import { useSharedReplay } from '../../hooks/useSharedReplay';
 
 /**
@@ -17,7 +18,7 @@ export function SharedReplayViewer() {
 
   // Single source of truth for playback state and world data
   const {
-    worldState, playing, currentTime, duration,
+    keyframes, worldState, playing, currentTime, duration,
     loading, error, play, pause, seek, sharedData,
   } = useSharedReplay(token ?? null);
 
@@ -81,6 +82,9 @@ export function SharedReplayViewer() {
           )}
         </div>
       </header>
+
+      {/* Agent swim-lane timeline */}
+      <ReplayTimeline keyframes={keyframes} duration={duration} currentTime={currentTime} onSeek={seek} />
 
       {/* Session content — rendered from replay world state */}
       <ReplayContent worldState={worldState} />

--- a/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
+++ b/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
@@ -3,7 +3,9 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { Users, Clock, Play, Pause, SkipBack, SkipForward, MapPin } from 'lucide-react';
 import type { ShareableReplay } from './types';
 import { AnnotationPin } from './AnnotationPin';
+import { ReplayContent } from './ReplayContent';
 import { apiFetch } from '../../hooks/useApi';
+import { useSessionReplay } from '../../hooks/useSessionReplay';
 
 /**
  * Read-only shared replay viewer — /shared/:token route.
@@ -18,6 +20,9 @@ export function SharedReplayViewer() {
   const [playing, setPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [showAnnotations, setShowAnnotations] = useState(false);
+
+  // Session replay hook — fetches world state as scrubber moves
+  const replayState = useSessionReplay(replay?.leadId ?? null);
 
   useEffect(() => {
     if (!token) return;
@@ -57,6 +62,13 @@ export function SharedReplayViewer() {
   const duration = replay.stats.duration * 1000;
   const progressPct = duration > 0 ? (currentTime / duration) * 100 : 0;
 
+  // Sync scrubber position with replay hook
+  const seekTo = (ms: number) => {
+    const clamped = Math.max(0, Math.min(ms, duration));
+    setCurrentTime(clamped);
+    replayState.seek(clamped);
+  };
+
   const formatTime = (ms: number) => {
     const s = Math.floor(ms / 1000);
     return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, '0')}`;
@@ -80,21 +92,16 @@ export function SharedReplayViewer() {
         </div>
       </header>
 
-      {/* Content placeholder — simplified read-only view */}
-      <div className="flex-1 flex items-center justify-center text-center p-8">
-        <div>
-          <p className="text-4xl mb-3">📼</p>
-          <p className="text-sm text-th-text-alt">Session replay at {formatTime(currentTime)}</p>
-          <p className="text-xs text-th-text-muted mt-1">
-            {replay.stats.taskCount} tasks
-          </p>
-        </div>
-      </div>
+      {/* Session content — rendered from replay world state */}
+      <ReplayContent
+        worldState={replayState.worldState}
+        loading={replayState.loading}
+      />
 
       {/* Scrubber */}
       <div className="border-t border-th-border px-4 py-3">
         <div className="flex items-center gap-3">
-          <button onClick={() => setCurrentTime(Math.max(0, currentTime - 5000))} className="p-1 text-th-text-muted hover:text-th-text">
+          <button onClick={() => seekTo(currentTime - 5000)} className="p-1 text-th-text-muted hover:text-th-text">
             <SkipBack className="w-4 h-4" />
           </button>
           <button
@@ -103,7 +110,7 @@ export function SharedReplayViewer() {
           >
             {playing ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
           </button>
-          <button onClick={() => setCurrentTime(Math.min(duration, currentTime + 5000))} className="p-1 text-th-text-muted hover:text-th-text">
+          <button onClick={() => seekTo(currentTime + 5000)} className="p-1 text-th-text-muted hover:text-th-text">
             <SkipForward className="w-4 h-4" />
           </button>
 
@@ -116,7 +123,7 @@ export function SharedReplayViewer() {
             className="flex-1 h-6 bg-th-bg-alt rounded relative cursor-pointer"
             onClick={(e) => {
               const rect = e.currentTarget.getBoundingClientRect();
-              setCurrentTime(((e.clientX - rect.left) / rect.width) * duration);
+              seekTo(((e.clientX - rect.left) / rect.width) * duration);
             }}
           >
             <div className="absolute inset-y-0 left-0 bg-accent/15 rounded" style={{ width: `${progressPct}%` }} />
@@ -129,7 +136,7 @@ export function SharedReplayViewer() {
                   key={ann.id}
                   annotation={ann}
                   position={Math.max(0, Math.min(100, pos))}
-                  onClick={() => setCurrentTime(Math.max(0, annTime))}
+                  onClick={() => seekTo(Math.max(0, annTime))}
                 />
               );
             })}

--- a/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
+++ b/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { Users, Clock, Play, Pause, SkipBack, SkipForward, MapPin } from 'lucide-react';
+import { Users, Clock, Play, Pause, SkipBack, SkipForward } from 'lucide-react';
 import type { ShareableReplay } from './types';
 import { AnnotationPin } from './AnnotationPin';
 import { ReplayContent } from './ReplayContent';
@@ -14,7 +13,6 @@ import { useSharedReplay } from '../../hooks/useSharedReplay';
 export function SharedReplayViewer() {
   const { token } = useParams<{ token: string }>();
   const [_searchParams] = useSearchParams();
-  const [showAnnotations, setShowAnnotations] = useState(false);
 
   // Single source of truth for playback state and world data
   const {
@@ -57,7 +55,8 @@ export function SharedReplayViewer() {
   const title = replay?.title ?? sharedData.label ?? 'Session Replay';
   const annotations = replay?.annotations ?? [];
   const createdBy = replay?.createdBy;
-  const createdAt = replay?.createdAt ?? sharedData.keyframes[0]?.timestamp;
+  // Use session start (first keyframe) for annotation time offsets, not share creation time
+  const sessionStart = sharedData.keyframes[0]?.timestamp;
   const statsDuration = replay?.stats?.duration;
   const statsAgents = replay?.stats?.agentCount;
 
@@ -120,8 +119,8 @@ export function SharedReplayViewer() {
             <div className="absolute inset-y-0 left-0 bg-accent/15 rounded" style={{ width: `${progressPct}%` }} />
             {/* Annotation pins */}
             {annotations.map((ann) => {
-              const annTime = createdAt
-                ? new Date(ann.timestamp).getTime() - new Date(createdAt).getTime()
+              const annTime = sessionStart
+                ? new Date(ann.timestamp).getTime() - new Date(sessionStart).getTime()
                 : 0;
               const pos = duration > 0 ? (annTime / duration) * 100 : 0;
               return (
@@ -139,14 +138,11 @@ export function SharedReplayViewer() {
             />
           </div>
 
-          {/* Annotations button */}
+          {/* Annotation count */}
           {annotations.length > 0 && (
-            <button
-              onClick={() => setShowAnnotations(!showAnnotations)}
-              className="flex items-center gap-1 px-2 py-1 text-[11px] text-th-text-muted hover:text-th-text rounded"
-            >
-              <MapPin className="w-3 h-3" /> {annotations.length}
-            </button>
+            <span className="flex items-center gap-1 px-2 py-1 text-[11px] text-th-text-muted">
+              📌 {annotations.length}
+            </span>
           )}
         </div>
       </div>

--- a/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
+++ b/packages/web/src/components/SessionReplay/SharedReplayViewer.tsx
@@ -1,40 +1,33 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { Users, Clock, Play, Pause, SkipBack, SkipForward, MapPin } from 'lucide-react';
 import type { ShareableReplay } from './types';
 import { AnnotationPin } from './AnnotationPin';
 import { ReplayContent } from './ReplayContent';
-import { apiFetch } from '../../hooks/useApi';
-import { useSessionReplay } from '../../hooks/useSessionReplay';
+import { useSharedReplay } from '../../hooks/useSharedReplay';
 
 /**
  * Read-only shared replay viewer — /shared/:token route.
- * Fetches replay data via the share token (no auth required).
+ * All data fetches go through the share token to enforce expiry/revocation.
  */
 export function SharedReplayViewer() {
   const { token } = useParams<{ token: string }>();
   const [_searchParams] = useSearchParams();
-  const [replay, setReplay] = useState<ShareableReplay | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [playing, setPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
   const [showAnnotations, setShowAnnotations] = useState(false);
 
-  // Session replay hook — fetches world state as scrubber moves
-  const replayState = useSessionReplay(replay?.leadId ?? null);
+  // Single source of truth for playback state and world data
+  const {
+    worldState, playing, currentTime, duration,
+    loading, error, play, pause, seek, sharedData,
+  } = useSharedReplay(token ?? null);
 
-  useEffect(() => {
-    if (!token) return;
-    setLoading(true);
-    apiFetch<ShareableReplay>(`/shared/${token}`)
-      .then((data) => setReplay(data))
-      .catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        setError(msg.includes('404') ? 'Replay not found or link expired' : msg);
-      })
-      .finally(() => setLoading(false));
-  }, [token]);
+  // Treat sharedData as metadata — cast for annotations/stats display
+  const replay = sharedData as unknown as ShareableReplay | null;
+
+  const formatTime = (ms: number) => {
+    const s = Math.floor(ms / 1000);
+    return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, '0')}`;
+  };
 
   if (loading) {
     return (
@@ -47,7 +40,7 @@ export function SharedReplayViewer() {
     );
   }
 
-  if (error || !replay) {
+  if (error || !sharedData) {
     return (
       <div className="min-h-screen bg-th-bg flex items-center justify-center" data-testid="shared-replay-error">
         <div className="text-center">
@@ -59,58 +52,52 @@ export function SharedReplayViewer() {
     );
   }
 
-  const duration = replay.stats.duration * 1000;
   const progressPct = duration > 0 ? (currentTime / duration) * 100 : 0;
-
-  // Sync scrubber position with replay hook
-  const seekTo = (ms: number) => {
-    const clamped = Math.max(0, Math.min(ms, duration));
-    setCurrentTime(clamped);
-    replayState.seek(clamped);
-  };
-
-  const formatTime = (ms: number) => {
-    const s = Math.floor(ms / 1000);
-    return `${Math.floor(s / 60)}:${(s % 60).toString().padStart(2, '0')}`;
-  };
+  const title = replay?.title ?? sharedData.label ?? 'Session Replay';
+  const annotations = replay?.annotations ?? [];
+  const createdBy = replay?.createdBy;
+  const createdAt = replay?.createdAt ?? sharedData.keyframes[0]?.timestamp;
+  const statsDuration = replay?.stats?.duration;
+  const statsAgents = replay?.stats?.agentCount;
 
   return (
     <div className="min-h-screen bg-th-bg flex flex-col" data-testid="shared-replay-viewer">
       {/* Header */}
       <header className="border-b border-th-border px-6 py-4">
-        <h1 className="text-lg font-semibold text-th-text-alt">📼 {replay.title}</h1>
+        <h1 className="text-lg font-semibold text-th-text-alt">📼 {title}</h1>
         <div className="flex items-center gap-4 mt-1">
-          <span className="text-xs text-th-text-muted">
-            Shared by {replay.createdBy}
-          </span>
-          <span className="text-xs text-th-text-muted flex items-center gap-1">
-            <Clock className="w-3 h-3" /> {Math.round(replay.stats.duration / 60)} min
-          </span>
-          <span className="text-xs text-th-text-muted flex items-center gap-1">
-            <Users className="w-3 h-3" /> {replay.stats.agentCount} agents
-          </span>
+          {createdBy && (
+            <span className="text-xs text-th-text-muted">Shared by {createdBy}</span>
+          )}
+          {statsDuration != null && (
+            <span className="text-xs text-th-text-muted flex items-center gap-1">
+              <Clock className="w-3 h-3" /> {Math.round(statsDuration / 60)} min
+            </span>
+          )}
+          {statsAgents != null && (
+            <span className="text-xs text-th-text-muted flex items-center gap-1">
+              <Users className="w-3 h-3" /> {statsAgents} agents
+            </span>
+          )}
         </div>
       </header>
 
       {/* Session content — rendered from replay world state */}
-      <ReplayContent
-        worldState={replayState.worldState}
-        loading={replayState.loading}
-      />
+      <ReplayContent worldState={worldState} />
 
       {/* Scrubber */}
       <div className="border-t border-th-border px-4 py-3">
         <div className="flex items-center gap-3">
-          <button onClick={() => seekTo(currentTime - 5000)} className="p-1 text-th-text-muted hover:text-th-text">
+          <button onClick={() => seek(currentTime - 5000)} className="p-1 text-th-text-muted hover:text-th-text">
             <SkipBack className="w-4 h-4" />
           </button>
           <button
-            onClick={() => setPlaying(!playing)}
+            onClick={() => playing ? pause() : play()}
             className="p-2 rounded-full bg-accent/20 text-accent hover:bg-accent/30"
           >
             {playing ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
           </button>
-          <button onClick={() => seekTo(currentTime + 5000)} className="p-1 text-th-text-muted hover:text-th-text">
+          <button onClick={() => seek(currentTime + 5000)} className="p-1 text-th-text-muted hover:text-th-text">
             <SkipForward className="w-4 h-4" />
           </button>
 
@@ -123,20 +110,22 @@ export function SharedReplayViewer() {
             className="flex-1 h-6 bg-th-bg-alt rounded relative cursor-pointer"
             onClick={(e) => {
               const rect = e.currentTarget.getBoundingClientRect();
-              seekTo(((e.clientX - rect.left) / rect.width) * duration);
+              seek(((e.clientX - rect.left) / rect.width) * duration);
             }}
           >
             <div className="absolute inset-y-0 left-0 bg-accent/15 rounded" style={{ width: `${progressPct}%` }} />
             {/* Annotation pins */}
-            {replay.annotations.map((ann) => {
-              const annTime = new Date(ann.timestamp).getTime() - new Date(replay.createdAt).getTime();
+            {annotations.map((ann) => {
+              const annTime = createdAt
+                ? new Date(ann.timestamp).getTime() - new Date(createdAt).getTime()
+                : 0;
               const pos = duration > 0 ? (annTime / duration) * 100 : 0;
               return (
                 <AnnotationPin
                   key={ann.id}
                   annotation={ann}
                   position={Math.max(0, Math.min(100, pos))}
-                  onClick={() => seekTo(Math.max(0, annTime))}
+                  onClick={() => seek(Math.max(0, annTime))}
                 />
               );
             })}
@@ -147,12 +136,12 @@ export function SharedReplayViewer() {
           </div>
 
           {/* Annotations button */}
-          {replay.annotations.length > 0 && (
+          {annotations.length > 0 && (
             <button
               onClick={() => setShowAnnotations(!showAnnotations)}
               className="flex items-center gap-1 px-2 py-1 text-[11px] text-th-text-muted hover:text-th-text rounded"
             >
-              <MapPin className="w-3 h-3" /> {replay.annotations.length}
+              <MapPin className="w-3 h-3" /> {annotations.length}
             </button>
           )}
         </div>

--- a/packages/web/src/components/SessionReplay/__tests__/ReplayContent.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/ReplayContent.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ReplayContent } from '../ReplayContent';
+import type { ReplayWorldState } from '../../../hooks/useSessionReplay';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const baseWorldState: ReplayWorldState = {
+  timestamp: '2026-03-20T12:00:00Z',
+  agents: [
+    { id: 'lead-uuid-1234', role: 'lead', status: 'running' },
+    { id: 'dev-uuid-5678', role: 'developer', status: 'running', contextUsedPct: 45 },
+    { id: 'rev-uuid-9012', role: 'code-reviewer', status: 'idle' },
+  ],
+  pendingDecisions: 1,
+  completedTasks: 3,
+  totalTasks: 7,
+  dagTasks: [
+    { id: 'setup-auth', description: 'Set up authentication', dagStatus: 'done', assignedTo: 'dev-uuid-5678' },
+    { id: 'build-api', description: 'Build REST API', dagStatus: 'running', role: 'developer' },
+    { id: 'write-tests', dagStatus: 'pending' },
+  ],
+  decisions: [
+    { id: 'dec-1', summary: 'Use JWT for auth tokens', status: 'confirmed', agentRole: 'lead' },
+    { id: 'dec-2', summary: 'Add rate limiting?', status: 'pending', agentRole: 'developer' },
+  ],
+  recentActivity: [
+    { id: 1, agentId: 'dev-uuid-5678', agentRole: 'developer', actionType: 'task_completed', summary: 'Auth module complete', timestamp: '2026-03-20T11:58:00Z' },
+    { id: 2, agentId: 'lead-uuid-1234', agentRole: 'lead', actionType: 'progress_update', summary: 'Phase 1 done', timestamp: '2026-03-20T11:55:00Z' },
+  ],
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('ReplayContent', () => {
+  it('renders empty state when worldState is null', () => {
+    render(<ReplayContent worldState={null} />);
+    expect(screen.getByTestId('replay-content-empty')).toBeTruthy();
+    expect(screen.getByText('Scrub the timeline to see session state')).toBeTruthy();
+  });
+
+  it('renders loading spinner', () => {
+    render(<ReplayContent worldState={null} loading />);
+    expect(screen.getByTestId('replay-content-loading')).toBeTruthy();
+  });
+
+  it('renders agent roster from world state', () => {
+    render(<ReplayContent worldState={baseWorldState} />);
+    const agents = screen.getAllByTestId('replay-agent');
+    expect(agents).toHaveLength(3);
+    expect(screen.getByText('lead')).toBeTruthy();
+    expect(screen.getByText('developer')).toBeTruthy();
+    expect(screen.getByText('code-reviewer')).toBeTruthy();
+  });
+
+  it('renders task DAG from world state', () => {
+    render(<ReplayContent worldState={baseWorldState} />);
+    const tasks = screen.getAllByTestId('replay-task');
+    expect(tasks).toHaveLength(3);
+    expect(screen.getByText('setup-auth')).toBeTruthy();
+    expect(screen.getByText('build-api')).toBeTruthy();
+    expect(screen.getByText('write-tests')).toBeTruthy();
+  });
+
+  it('renders decisions from world state', () => {
+    render(<ReplayContent worldState={baseWorldState} />);
+    const decisions = screen.getAllByTestId('replay-decision');
+    expect(decisions).toHaveLength(2);
+    expect(screen.getByText('Use JWT for auth tokens')).toBeTruthy();
+    expect(screen.getByText('Add rate limiting?')).toBeTruthy();
+  });
+
+  it('renders activity feed from world state', () => {
+    render(<ReplayContent worldState={baseWorldState} />);
+    const activities = screen.getAllByTestId('replay-activity');
+    expect(activities).toHaveLength(2);
+    expect(screen.getByText('Auth module complete')).toBeTruthy();
+    expect(screen.getByText('Phase 1 done')).toBeTruthy();
+  });
+
+  it('renders summary bar with counts', () => {
+    render(<ReplayContent worldState={baseWorldState} />);
+    expect(screen.getByText('3 agents (2 running)')).toBeTruthy();
+    expect(screen.getByText('3/7 tasks')).toBeTruthy();
+    expect(screen.getByText('1 pending decisions')).toBeTruthy();
+  });
+
+  it('handles world state with no tasks or decisions', () => {
+    const minimal: ReplayWorldState = {
+      timestamp: '2026-03-20T12:00:00Z',
+      agents: [{ id: 'a1', role: 'lead', status: 'running' }],
+      pendingDecisions: 0,
+      completedTasks: 0,
+      totalTasks: 0,
+    };
+    render(<ReplayContent worldState={minimal} />);
+    expect(screen.getByTestId('replay-content')).toBeTruthy();
+    expect(screen.getByText('No tasks or decisions at this point')).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/SessionReplay/__tests__/ReplayContent.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/ReplayContent.test.tsx
@@ -12,17 +12,14 @@ const baseWorldState: ReplayWorldState = {
     { id: 'dev-uuid-5678', role: 'developer', status: 'running', contextUsedPct: 45 },
     { id: 'rev-uuid-9012', role: 'code-reviewer', status: 'idle' },
   ],
-  pendingDecisions: 1,
-  completedTasks: 3,
-  totalTasks: 7,
   dagTasks: [
-    { id: 'setup-auth', description: 'Set up authentication', dagStatus: 'done', assignedTo: 'dev-uuid-5678' },
+    { id: 'setup-auth', description: 'Set up authentication', dagStatus: 'done', assignedAgentId: 'dev-uuid-5678' },
     { id: 'build-api', description: 'Build REST API', dagStatus: 'running', role: 'developer' },
     { id: 'write-tests', dagStatus: 'pending' },
   ],
   decisions: [
-    { id: 'dec-1', summary: 'Use JWT for auth tokens', status: 'confirmed', agentRole: 'lead' },
-    { id: 'dec-2', summary: 'Add rate limiting?', status: 'pending', agentRole: 'developer' },
+    { id: 'dec-1', title: 'Use JWT for auth tokens', status: 'confirmed', agentRole: 'lead' },
+    { id: 'dec-2', title: 'Add rate limiting?', status: 'pending', agentRole: 'developer' },
   ],
   recentActivity: [
     { id: 1, agentId: 'dev-uuid-5678', agentRole: 'developer', actionType: 'task_completed', summary: 'Auth module complete', timestamp: '2026-03-20T11:58:00Z' },
@@ -78,10 +75,12 @@ describe('ReplayContent', () => {
     expect(screen.getByText('Phase 1 done')).toBeTruthy();
   });
 
-  it('renders summary bar with counts', () => {
+  it('renders summary bar with counts derived from arrays', () => {
     render(<ReplayContent worldState={baseWorldState} />);
     expect(screen.getByText('3 agents (2 running)')).toBeTruthy();
-    expect(screen.getByText('3/7 tasks')).toBeTruthy();
+    // 1 done out of 3 tasks (derived from dagTasks array)
+    expect(screen.getByText('1/3 tasks')).toBeTruthy();
+    // 1 pending decision (derived from decisions array)
     expect(screen.getByText('1 pending decisions')).toBeTruthy();
   });
 
@@ -89,9 +88,6 @@ describe('ReplayContent', () => {
     const minimal: ReplayWorldState = {
       timestamp: '2026-03-20T12:00:00Z',
       agents: [{ id: 'a1', role: 'lead', status: 'running' }],
-      pendingDecisions: 0,
-      completedTasks: 0,
-      totalTasks: 0,
     };
     render(<ReplayContent worldState={minimal} />);
     expect(screen.getByTestId('replay-content')).toBeTruthy();

--- a/packages/web/src/components/SessionReplay/__tests__/ReplayScrubber.extra.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/ReplayScrubber.extra.test.tsx
@@ -88,9 +88,19 @@ describe('ReplayScrubber – extra coverage', () => {
         { id: 'a2', status: 'running' },
         { id: 'a3', status: 'idle' },
       ],
-      totalTasks: 10,
-      completedTasks: 5,
-      pendingDecisions: 0,
+      dagTasks: [
+        { id: 't1', dagStatus: 'done' },
+        { id: 't2', dagStatus: 'done' },
+        { id: 't3', dagStatus: 'done' },
+        { id: 't4', dagStatus: 'done' },
+        { id: 't5', dagStatus: 'done' },
+        { id: 't6', dagStatus: 'running' },
+        { id: 't7', dagStatus: 'running' },
+        { id: 't8', dagStatus: 'pending' },
+        { id: 't9', dagStatus: 'pending' },
+        { id: 't10', dagStatus: 'pending' },
+      ],
+      decisions: [],
     };
     const kf: ReplayKeyframe[] = [
       { type: 'spawn', timestamp: '2024-01-01T00:00:00Z', label: 'A', agentId: 'a1' },
@@ -110,9 +120,12 @@ describe('ReplayScrubber – extra coverage', () => {
   it('renders pending decisions in world state', () => {
     const worldState = {
       agents: [{ id: 'a1', status: 'running' }],
-      totalTasks: 0,
-      completedTasks: 0,
-      pendingDecisions: 3,
+      dagTasks: [],
+      decisions: [
+        { id: 'd1', title: 'D1', status: 'pending' },
+        { id: 'd2', title: 'D2', status: 'pending' },
+        { id: 'd3', title: 'D3', status: 'pending' },
+      ],
     };
     const kf: ReplayKeyframe[] = [
       { type: 'spawn', timestamp: '2024-01-01T00:00:00Z', label: 'A', agentId: 'a1' },
@@ -127,12 +140,11 @@ describe('ReplayScrubber – extra coverage', () => {
     expect(screen.getByText('3 pending')).toBeInTheDocument();
   });
 
-  it('does not show tasks when totalTasks is 0', () => {
+  it('does not show tasks when dagTasks is empty', () => {
     const worldState = {
       agents: [{ id: 'a1', status: 'idle' }],
-      totalTasks: 0,
-      completedTasks: 0,
-      pendingDecisions: 0,
+      dagTasks: [],
+      decisions: [],
     };
     const kf: ReplayKeyframe[] = [
       { type: 'spawn', timestamp: '2024-01-01T00:00:00Z', label: 'A', agentId: 'a1' },

--- a/packages/web/src/components/SessionReplay/__tests__/ReplayScrubber.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/ReplayScrubber.test.tsx
@@ -223,9 +223,16 @@ describe('ReplayScrubber', () => {
               { id: 'a1', role: 'dev', status: 'running' },
               { id: 'a2', role: 'arch', status: 'idle' },
             ],
-            pendingDecisions: 1,
-            completedTasks: 3,
-            totalTasks: 5,
+            dagTasks: [
+              { id: 't1', dagStatus: 'done' },
+              { id: 't2', dagStatus: 'done' },
+              { id: 't3', dagStatus: 'done' },
+              { id: 't4', dagStatus: 'running' },
+              { id: 't5', dagStatus: 'pending' },
+            ],
+            decisions: [
+              { id: 'd1', title: 'Dec', status: 'pending' },
+            ],
           },
         }}
       />,

--- a/packages/web/src/components/SessionReplay/__tests__/ReplayTimeline.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/ReplayTimeline.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReplayTimeline } from '../ReplayTimeline';
+import type { ReplayKeyframe } from '../../../hooks/useSessionReplay';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const BASE_TIME = new Date('2026-03-20T12:00:00Z').getTime();
+
+function kf(type: ReplayKeyframe['type'], offsetMs: number, agentId?: string, label = ''): ReplayKeyframe {
+  return {
+    type,
+    timestamp: new Date(BASE_TIME + offsetMs).toISOString(),
+    agentId,
+    label: label || type,
+  };
+}
+
+const KEYFRAMES: ReplayKeyframe[] = [
+  kf('spawn', 0, 'lead-1111', 'Spawned lead'),
+  kf('spawn', 1000, 'dev-2222', 'Spawned developer'),
+  kf('progress', 5000, 'dev-2222', 'Progress update'),
+  kf('agent_exit', 8000, 'dev-2222', 'Developer exited'),
+  kf('agent_exit', 10000, 'lead-1111', 'Lead exited'),
+];
+
+const DURATION = 10000;
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('ReplayTimeline', () => {
+  it('renders nothing when keyframes are empty', () => {
+    const { container } = render(
+      <ReplayTimeline keyframes={[]} duration={0} currentTime={0} onSeek={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a swim lane per agent', () => {
+    render(
+      <ReplayTimeline keyframes={KEYFRAMES} duration={DURATION} currentTime={0} onSeek={() => {}} />
+    );
+    expect(screen.getByTestId('replay-timeline')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-bar-lead-111')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-bar-dev-2222')).toBeInTheDocument();
+  });
+
+  it('shows role labels', () => {
+    render(
+      <ReplayTimeline keyframes={KEYFRAMES} duration={DURATION} currentTime={0} onSeek={() => {}} />
+    );
+    expect(screen.getByText(/lead/i)).toBeInTheDocument();
+    expect(screen.getByText(/developer/i)).toBeInTheDocument();
+  });
+
+  it('calls onSeek when clicking on a bar track', () => {
+    const onSeek = vi.fn();
+    render(
+      <ReplayTimeline keyframes={KEYFRAMES} duration={DURATION} currentTime={0} onSeek={onSeek} />
+    );
+    // Click on the first bar track container
+    const bars = screen.getByTestId('agent-bar-lead-111').parentElement!;
+    fireEvent.click(bars, { clientX: 50 });
+    expect(onSeek).toHaveBeenCalled();
+  });
+
+  it('developer bar does not span the full duration', () => {
+    render(
+      <ReplayTimeline keyframes={KEYFRAMES} duration={DURATION} currentTime={0} onSeek={() => {}} />
+    );
+    const devBar = screen.getByTestId('agent-bar-dev-2222');
+    const style = devBar.style;
+    // Developer spawns at 1000ms (10%) and exits at 8000ms (80%) → width ~70%
+    expect(parseFloat(style.left)).toBeCloseTo(10, 0);
+    expect(parseFloat(style.width)).toBeCloseTo(70, 0);
+  });
+
+  it('lead bar spans the full duration', () => {
+    render(
+      <ReplayTimeline keyframes={KEYFRAMES} duration={DURATION} currentTime={0} onSeek={() => {}} />
+    );
+    const leadBar = screen.getByTestId('agent-bar-lead-111');
+    // Lead spawns at 0 (0%) and exits at 10000ms (100%) → width 100%
+    expect(parseFloat(leadBar.style.left)).toBeCloseTo(0, 0);
+    expect(parseFloat(leadBar.style.width)).toBeCloseTo(100, 0);
+  });
+
+  it('handles agents without exit keyframe (still running)', () => {
+    const keyframes: ReplayKeyframe[] = [
+      kf('spawn', 0, 'lead-1111', 'Spawned lead'),
+      kf('spawn', 2000, 'dev-2222', 'Spawned developer'),
+    ];
+    render(
+      <ReplayTimeline keyframes={keyframes} duration={10000} currentTime={5000} onSeek={() => {}} />
+    );
+    // Both should render — dev bar extends to full duration since no exit
+    expect(screen.getByTestId('agent-bar-lead-111')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-bar-dev-2222')).toBeInTheDocument();
+    const devBar = screen.getByTestId('agent-bar-dev-2222');
+    expect(parseFloat(devBar.style.width)).toBeCloseTo(80, 0);
+  });
+});

--- a/packages/web/src/components/SessionReplay/__tests__/SharedReplayViewer.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/SharedReplayViewer.test.tsx
@@ -4,9 +4,15 @@ import type { ShareableReplay } from '../types';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────
 
-const mockApiFetch = vi.fn();
-vi.mock('../../../hooks/useApi', () => ({
-  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+const mockPlay = vi.fn();
+const mockPause = vi.fn();
+const mockSeek = vi.fn();
+const mockSetSpeed = vi.fn();
+
+let mockHookReturn: Record<string, unknown> = {};
+
+vi.mock('../../../hooks/useSharedReplay', () => ({
+  useSharedReplay: () => mockHookReturn,
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -14,7 +20,6 @@ vi.mock('react-router-dom', () => ({
   useSearchParams: () => [new URLSearchParams()],
 }));
 
-// Mock AnnotationPin to simplify testing
 vi.mock('../AnnotationPin', () => ({
   AnnotationPin: ({ annotation, onClick }: { annotation: { id: string; text: string }; onClick: () => void }) => (
     <div data-testid={`annotation-${annotation.id}`} onClick={onClick}>
@@ -23,26 +28,6 @@ vi.mock('../AnnotationPin', () => ({
   ),
 }));
 
-// Mock useSessionReplay hook
-const mockSeek = vi.fn();
-vi.mock('../../../hooks/useSessionReplay', () => ({
-  useSessionReplay: () => ({
-    keyframes: [],
-    worldState: null,
-    playing: false,
-    currentTime: 0,
-    duration: 0,
-    loading: false,
-    error: null,
-    play: vi.fn(),
-    pause: vi.fn(),
-    seek: mockSeek,
-    setSpeed: vi.fn(),
-    speed: 4,
-  }),
-}));
-
-// Mock ReplayContent to simplify testing
 vi.mock('../ReplayContent', () => ({
   ReplayContent: ({ worldState, loading }: { worldState: unknown; loading?: boolean }) => (
     <div data-testid="replay-content-mock">
@@ -55,211 +40,169 @@ import { SharedReplayViewer } from '../SharedReplayViewer';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
-const baseReplay: ShareableReplay = {
-  id: 'replay-1',
-  sessionId: 'session-1',
+const baseSharedData = {
   leadId: 'lead-1',
+  label: 'Test label',
+  expiresAt: '2026-12-31T00:00:00Z',
+  keyframes: [
+    { timestamp: '2024-01-01T00:00:00Z', label: 'Start', type: 'spawn' },
+    { timestamp: '2024-01-01T00:10:00Z', label: 'End', type: 'milestone' },
+  ],
+  // ShareableReplay fields for metadata display
   title: 'Test Session Replay',
   createdAt: '2024-01-01T00:00:00Z',
   createdBy: 'alice',
-  format: 'link',
-  annotations: [],
+  annotations: [] as ShareableReplay['annotations'],
   highlights: [],
-  stats: {
-    duration: 600, // 10 minutes in seconds
-    agentCount: 3,
-    taskCount: 12,
-    totalCost: 1.5,
-  },
+  stats: { duration: 600, agentCount: 3, taskCount: 12, totalCost: 1.5 },
 };
 
-const replayWithAnnotations: ShareableReplay = {
-  ...baseReplay,
+const sharedDataWithAnnotations = {
+  ...baseSharedData,
   annotations: [
-    { id: 'ann-1', timestamp: '2024-01-01T00:03:00Z', author: 'bob', text: 'Key decision here', type: 'comment' },
-    { id: 'ann-2', timestamp: '2024-01-01T00:07:00Z', author: 'alice', text: 'Bug found', type: 'flag' },
+    { id: 'ann-1', timestamp: '2024-01-01T00:03:00Z', author: 'bob', text: 'Key decision here', type: 'comment' as const },
+    { id: 'ann-2', timestamp: '2024-01-01T00:07:00Z', author: 'alice', text: 'Bug found', type: 'flag' as const },
   ],
 };
+
+function makeHookReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    keyframes: baseSharedData.keyframes,
+    worldState: null,
+    playing: false,
+    currentTime: 0,
+    duration: 600_000, // 10 min in ms
+    loading: false,
+    error: null,
+    play: mockPlay,
+    pause: mockPause,
+    seek: mockSeek,
+    setSpeed: mockSetSpeed,
+    speed: 4,
+    sharedData: baseSharedData,
+    ...overrides,
+  };
+}
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 describe('SharedReplayViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockApiFetch.mockReset();
+    mockHookReturn = makeHookReturn();
   });
 
-  it('shows loading state initially', async () => {
-    mockApiFetch.mockReturnValue(new Promise(() => {})); // never resolves
+  it('shows loading state when hook is loading', () => {
+    mockHookReturn = makeHookReturn({ loading: true, sharedData: null });
     render(<SharedReplayViewer />);
-    await act(async () => {});
     expect(screen.getByText('Loading shared replay...')).toBeInTheDocument();
   });
 
-  it('fetches replay data with the token', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('renders replay viewer after data loads', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    expect(mockApiFetch).toHaveBeenCalledWith('/shared/abc-123');
+    expect(screen.getByTestId('shared-replay-viewer')).toBeInTheDocument();
   });
 
-  it('renders replay viewer after successful fetch', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('displays replay title in header', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByTestId('shared-replay-viewer')).toBeInTheDocument();
+    expect(screen.getByText(/Test Session Replay/)).toBeInTheDocument();
+  });
+
+  it('displays shared-by info', () => {
+    render(<SharedReplayViewer />);
+    expect(screen.getByText(/Shared by alice/)).toBeInTheDocument();
+  });
+
+  it('displays duration in minutes', () => {
+    render(<SharedReplayViewer />);
+    expect(screen.getByText(/10 min/)).toBeInTheDocument();
+  });
+
+  it('displays agent count', () => {
+    render(<SharedReplayViewer />);
+    expect(screen.getByText(/3 agents/)).toBeInTheDocument();
+  });
+
+  it('renders ReplayContent component', () => {
+    render(<SharedReplayViewer />);
+    expect(screen.getByTestId('replay-content-mock')).toBeInTheDocument();
+  });
+
+  it('shows error state on token error', () => {
+    mockHookReturn = makeHookReturn({
+      error: 'Share link has expired or been revoked',
+      sharedData: null,
     });
+    render(<SharedReplayViewer />);
+    expect(screen.getByTestId('shared-replay-error')).toBeInTheDocument();
+    expect(screen.getByText('Share link has expired or been revoked')).toBeInTheDocument();
   });
 
-  it('displays replay title in header', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('shows error state when sharedData is null', () => {
+    mockHookReturn = makeHookReturn({ sharedData: null });
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText(/Test Session Replay/)).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('shared-replay-error')).toBeInTheDocument();
   });
 
-  it('displays shared-by info', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('shows expiry hint on error', () => {
+    mockHookReturn = makeHookReturn({ error: 'expired', sharedData: null });
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText(/Shared by alice/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/may have expired/)).toBeInTheDocument();
   });
 
-  it('displays duration in minutes', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('renders play/pause buttons', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText(/10 min/)).toBeInTheDocument();
-    });
-  });
-
-  it('displays agent count', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
-    render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText(/3 agents/)).toBeInTheDocument();
-    });
-  });
-
-  it('renders ReplayContent component', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
-    render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByTestId('replay-content-mock')).toBeInTheDocument();
-    });
-  });
-
-  it('shows error state on 404', async () => {
-    mockApiFetch.mockRejectedValue(new Error('404 Not Found'));
-    render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByTestId('shared-replay-error')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Replay not found or link expired')).toBeInTheDocument();
-  });
-
-  it('shows generic error message on non-404 failure', async () => {
-    mockApiFetch.mockRejectedValue(new Error('Server error'));
-    render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByTestId('shared-replay-error')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Server error')).toBeInTheDocument();
-  });
-
-  it('shows expiry hint on error', async () => {
-    mockApiFetch.mockRejectedValue(new Error('404'));
-    render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText(/may have expired/)).toBeInTheDocument();
-    });
-  });
-
-  it('renders play/pause toggle', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
-    render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => screen.getByTestId('shared-replay-viewer'));
-    // Initially not playing — Play icon is an SVG, check container button exists
     const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toBeGreaterThanOrEqual(3); // skip-back, play/pause, skip-forward
+    expect(buttons.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('shows initial time as 0:00', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('shows initial time as 0:00', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText('0:00')).toBeInTheDocument();
-    });
+    expect(screen.getByText('0:00')).toBeInTheDocument();
   });
 
-  it('shows total duration formatted', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('shows total duration formatted', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      // 600 seconds = 10:00
-      expect(screen.getByText('10:00')).toBeInTheDocument();
-    });
+    expect(screen.getByText('10:00')).toBeInTheDocument();
   });
 
-  it('renders annotation pins when present', async () => {
-    mockApiFetch.mockResolvedValue(replayWithAnnotations);
+  it('renders annotation pins when present', () => {
+    mockHookReturn = makeHookReturn({ sharedData: sharedDataWithAnnotations });
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByTestId('annotation-ann-1')).toBeInTheDocument();
-      expect(screen.getByTestId('annotation-ann-2')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('annotation-ann-1')).toBeInTheDocument();
+    expect(screen.getByTestId('annotation-ann-2')).toBeInTheDocument();
   });
 
-  it('shows annotation count button', async () => {
-    mockApiFetch.mockResolvedValue(replayWithAnnotations);
+  it('shows annotation count button', () => {
+    mockHookReturn = makeHookReturn({ sharedData: sharedDataWithAnnotations });
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => {
-      expect(screen.getByText('2')).toBeInTheDocument();
-    });
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
-  it('does not show annotation button when no annotations', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('does not show annotation button when no annotations', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => screen.getByTestId('shared-replay-viewer'));
-    // No annotation count button
     expect(screen.queryByText(/annotations/i)).not.toBeInTheDocument();
   });
 
-  it('advances time on skip-forward click', async () => {
-    mockApiFetch.mockResolvedValue(baseReplay);
+  it('calls seek on skip-forward click', () => {
     render(<SharedReplayViewer />);
-    await act(async () => {});
-    await waitFor(() => screen.getByTestId('shared-replay-viewer'));
-
-    // Find skip-forward button (third transport button)
     const buttons = screen.getAllByRole('button');
-    // Skip-forward is after play/pause
-    const skipForward = buttons[2];
-    await act(async () => {
-      fireEvent.click(skipForward);
-    });
+    fireEvent.click(buttons[2]); // skip-forward
+    expect(mockSeek).toHaveBeenCalledWith(5000); // currentTime(0) + 5000
+  });
 
-    // Time should advance by 5 seconds -> 0:05
-    await waitFor(() => {
-      expect(screen.getByText('0:05')).toBeInTheDocument();
-    });
+  it('calls play on play button click', () => {
+    render(<SharedReplayViewer />);
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[1]); // play/pause
+    expect(mockPlay).toHaveBeenCalled();
+  });
+
+  it('calls pause when playing and button clicked', () => {
+    mockHookReturn = makeHookReturn({ playing: true });
+    render(<SharedReplayViewer />);
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[1]); // play/pause
+    expect(mockPause).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/SessionReplay/__tests__/SharedReplayViewer.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/SharedReplayViewer.test.tsx
@@ -23,6 +23,34 @@ vi.mock('../AnnotationPin', () => ({
   ),
 }));
 
+// Mock useSessionReplay hook
+const mockSeek = vi.fn();
+vi.mock('../../../hooks/useSessionReplay', () => ({
+  useSessionReplay: () => ({
+    keyframes: [],
+    worldState: null,
+    playing: false,
+    currentTime: 0,
+    duration: 0,
+    loading: false,
+    error: null,
+    play: vi.fn(),
+    pause: vi.fn(),
+    seek: mockSeek,
+    setSpeed: vi.fn(),
+    speed: 4,
+  }),
+}));
+
+// Mock ReplayContent to simplify testing
+vi.mock('../ReplayContent', () => ({
+  ReplayContent: ({ worldState, loading }: { worldState: unknown; loading?: boolean }) => (
+    <div data-testid="replay-content-mock">
+      {loading ? 'loading' : worldState ? 'content' : 'empty'}
+    </div>
+  ),
+}));
+
 import { SharedReplayViewer } from '../SharedReplayViewer';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
@@ -120,12 +148,12 @@ describe('SharedReplayViewer', () => {
     });
   });
 
-  it('displays task count', async () => {
+  it('renders ReplayContent component', async () => {
     mockApiFetch.mockResolvedValue(baseReplay);
     render(<SharedReplayViewer />);
     await act(async () => {});
     await waitFor(() => {
-      expect(screen.getByText(/12 tasks/)).toBeInTheDocument();
+      expect(screen.getByTestId('replay-content-mock')).toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/components/SessionReplay/__tests__/SharedReplayViewer.test.tsx
+++ b/packages/web/src/components/SessionReplay/__tests__/SharedReplayViewer.test.tsx
@@ -173,10 +173,10 @@ describe('SharedReplayViewer', () => {
     expect(screen.getByTestId('annotation-ann-2')).toBeInTheDocument();
   });
 
-  it('shows annotation count button', () => {
+  it('shows annotation count', () => {
     mockHookReturn = makeHookReturn({ sharedData: sharedDataWithAnnotations });
     render(<SharedReplayViewer />);
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText(/📌 2/)).toBeInTheDocument();
   });
 
   it('does not show annotation button when no annotations', () => {

--- a/packages/web/src/components/SessionReplay/index.ts
+++ b/packages/web/src/components/SessionReplay/index.ts
@@ -1,5 +1,6 @@
 export { ReplayScrubber } from './ReplayScrubber';
 export { SharedReplayViewer } from './SharedReplayViewer';
 export { ReplayContent } from './ReplayContent';
+export { ReplayTimeline } from './ReplayTimeline';
 export { AnnotationPin } from './AnnotationPin';
 export type { ReplayAnnotation, ReplayHighlight, ShareableReplay } from './types';

--- a/packages/web/src/components/SessionReplay/index.ts
+++ b/packages/web/src/components/SessionReplay/index.ts
@@ -1,4 +1,5 @@
 export { ReplayScrubber } from './ReplayScrubber';
 export { SharedReplayViewer } from './SharedReplayViewer';
+export { ReplayContent } from './ReplayContent';
 export { AnnotationPin } from './AnnotationPin';
 export type { ReplayAnnotation, ReplayHighlight, ShareableReplay } from './types';

--- a/packages/web/src/hooks/useSessionReplay.ts
+++ b/packages/web/src/hooks/useSessionReplay.ts
@@ -26,9 +26,6 @@ export interface ReplayAgentState {
 export interface ReplayWorldState {
   timestamp: string;
   agents: ReplayAgentState[];
-  pendingDecisions: number;
-  completedTasks: number;
-  totalTasks: number;
   /** Full task DAG state at this point in time (from server WorldState) */
   dagTasks?: ReplayDagTask[];
   /** Decision log entries at this point in time */
@@ -42,13 +39,13 @@ export interface ReplayDagTask {
   description?: string;
   role?: string;
   dagStatus: string;
-  assignedTo?: string;
+  assignedAgentId?: string;
   dependencies?: string[];
 }
 
 export interface ReplayDecision {
   id: string;
-  summary: string;
+  title: string;
   status: string;
   agentRole?: string;
   timestamp?: string;

--- a/packages/web/src/hooks/useSessionReplay.ts
+++ b/packages/web/src/hooks/useSessionReplay.ts
@@ -29,6 +29,38 @@ export interface ReplayWorldState {
   pendingDecisions: number;
   completedTasks: number;
   totalTasks: number;
+  /** Full task DAG state at this point in time (from server WorldState) */
+  dagTasks?: ReplayDagTask[];
+  /** Decision log entries at this point in time */
+  decisions?: ReplayDecision[];
+  /** Recent activity entries near this timestamp */
+  recentActivity?: ReplayActivityEntry[];
+}
+
+export interface ReplayDagTask {
+  id: string;
+  description?: string;
+  role?: string;
+  dagStatus: string;
+  assignedTo?: string;
+  dependencies?: string[];
+}
+
+export interface ReplayDecision {
+  id: string;
+  summary: string;
+  status: string;
+  agentRole?: string;
+  timestamp?: string;
+}
+
+export interface ReplayActivityEntry {
+  id: number;
+  agentId: string;
+  agentRole: string;
+  actionType: string;
+  summary: string;
+  timestamp: string;
 }
 
 export interface UseSessionReplayResult {

--- a/packages/web/src/hooks/useSharedReplay.ts
+++ b/packages/web/src/hooks/useSharedReplay.ts
@@ -1,0 +1,170 @@
+/**
+ * Token-authenticated session replay hook for public share links.
+ *
+ * Routes ALL requests through /shared/:token/* endpoints to ensure
+ * token validation and expiry checks on every state fetch.
+ * This prevents the bypass where useSessionReplay(leadId) would
+ * skip token validation after the initial metadata load.
+ */
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './useApi';
+import type {
+  ReplayKeyframe,
+  ReplayWorldState,
+  UseSessionReplayResult,
+} from './useSessionReplay';
+import {
+  PLAYBACK_TICK_MS,
+  STATE_FETCH_DEBOUNCE_MS,
+  MIN_SESSION_DURATION_MS,
+} from '../constants/timing';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** Response from GET /shared/:token — initial metadata + keyframes */
+export interface SharedReplayData {
+  leadId: string;
+  label?: string;
+  expiresAt?: string;
+  keyframes: ReplayKeyframe[];
+  state?: ReplayWorldState;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────
+
+/**
+ * Token-routed replay hook for shared/public replay viewers.
+ * All requests go through /shared/:token/* — never /replay/:leadId/*.
+ */
+export function useSharedReplay(token: string | null): UseSessionReplayResult & {
+  /** Initial metadata from the share link */
+  sharedData: SharedReplayData | null;
+} {
+  const [worldState, setWorldState] = useState<ReplayWorldState | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [speed, setSpeed] = useState(4);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
+  const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const sessionStartRef = useRef<number>(0);
+
+  // Load initial data (keyframes + metadata) via share token
+  const { data: sharedData, isLoading: loading, error: queryError } = useQuery({
+    queryKey: ['shared-replay', token],
+    queryFn: async ({ signal }) => {
+      const data = await apiFetch<SharedReplayData>(
+        `/shared/${token}`,
+        { signal },
+      );
+      return data;
+    },
+    enabled: !!token,
+    retry: (failureCount, error) => {
+      // Don't retry on auth failures (expired/revoked tokens)
+      if (error instanceof Error && /40[134]/.test(error.message)) return false;
+      return failureCount < 2;
+    },
+  });
+
+  const keyframes = sharedData?.keyframes ?? [];
+  const error = tokenError
+    ?? (queryError ? (queryError instanceof Error ? queryError.message : String(queryError)) : null);
+
+  // Set initial world state from the metadata response
+  useEffect(() => {
+    if (sharedData?.state) {
+      setWorldState(sharedData.state);
+    }
+  }, [sharedData]);
+
+  // Derive duration and sessionStart from keyframes
+  useEffect(() => {
+    setCurrentTime(0);
+    setPlaying(false);
+    setWorldState(sharedData?.state ?? null);
+    sessionStartRef.current = 0;
+    setTokenError(null);
+
+    if (keyframes.length > 0) {
+      const start = new Date(keyframes[0].timestamp).getTime();
+      const end = new Date(keyframes[keyframes.length - 1].timestamp).getTime();
+      sessionStartRef.current = start;
+      setDuration(Math.max(end - start, MIN_SESSION_DURATION_MS));
+    } else {
+      setDuration(0);
+    }
+  }, [token, keyframes, sharedData?.state]);
+
+  // Fetch world state at a given time offset — routed through share token
+  const fetchStateAt = useCallback(async (timeMs: number) => {
+    if (!token || sessionStartRef.current === 0) return;
+    const iso = new Date(sessionStartRef.current + timeMs).toISOString();
+    try {
+      const state = await apiFetch<ReplayWorldState>(
+        `/shared/${token}/state?at=${encodeURIComponent(iso)}`,
+      );
+      setWorldState(state);
+      setTokenError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/40[134]/.test(msg)) {
+        // Token expired or revoked — surface error, stop playback
+        setTokenError('Share link has expired or been revoked');
+        setPlaying(false);
+      }
+      // Other errors: best-effort, don't interrupt playback
+    }
+  }, [token]);
+
+  // Playback loop
+  useEffect(() => {
+    if (playing) {
+      const tickMs = PLAYBACK_TICK_MS;
+      playIntervalRef.current = setInterval(() => {
+        setCurrentTime((prev) => {
+          const next = prev + tickMs * speed;
+          if (next >= duration) {
+            setPlaying(false);
+            return duration;
+          }
+          return next;
+        });
+      }, tickMs);
+    }
+    return () => {
+      if (playIntervalRef.current) clearInterval(playIntervalRef.current);
+    };
+  }, [playing, speed, duration]);
+
+  // Fetch world state when currentTime changes (debounced)
+  const lastFetchRef = useRef(0);
+  useEffect(() => {
+    const now = Date.now();
+    if (now - lastFetchRef.current < STATE_FETCH_DEBOUNCE_MS) return;
+    lastFetchRef.current = now;
+    fetchStateAt(currentTime);
+  }, [currentTime, fetchStateAt]);
+
+  const play = useCallback(() => {
+    if (currentTime >= duration) setCurrentTime(0);
+    setPlaying(true);
+  }, [currentTime, duration]);
+
+  const pause = useCallback(() => setPlaying(false), []);
+
+  const seek = useCallback((timeMs: number) => {
+    const clamped = Math.max(0, Math.min(timeMs, duration));
+    setCurrentTime(clamped);
+    setPlaying(false);
+    fetchStateAt(clamped);
+  }, [duration, fetchStateAt]);
+
+  return {
+    keyframes, worldState, playing, currentTime, duration,
+    loading, error, play, pause, seek, setSpeed, speed,
+    sharedData: sharedData ?? null,
+  };
+}


### PR DESCRIPTION
Adds agent swim-lane timeline visualization to the shared replay view.

## Changes
- ReplayTimeline component (~115 LOC): pure CSS swim lanes, role-based colors, click-to-seek, playhead tracking
- No new dependencies (pure CSS, no visx/d3)
- 7 tests

## Review
- Code ✅, Critical ✅, Readability ✅

Follow-up: role field on ReplayKeyframe for robust role detection (currently parses from label text).

Depends on PR #198 (Phase A).