### PR TITLE
feat: session replay share UI (Phase B)

### DIFF
--- a/packages/web/src/components/Timeline/ShareDialog.tsx
+++ b/packages/web/src/components/Timeline/ShareDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { X, Link2, Copy, Check, Trash2, Plus, Clock, ExternalLink } from 'lucide-react';
 import { apiFetch } from '../../hooks/useApi';
 
@@ -55,6 +55,14 @@ export function ShareDialog({ leadId, onClose }: ShareDialogProps) {
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
   const [expiryHours, setExpiryHours] = useState(168); // default 7 days
   const [label, setLabel] = useState('');
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up the "copied" timer on unmount
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
 
   // ESC to close
   useEffect(() => {
@@ -67,6 +75,7 @@ export function ShareDialog({ leadId, onClose }: ShareDialogProps) {
 
   // Fetch existing links
   const fetchLinks = useCallback(async () => {
+    setLoading(true);
     try {
       const data = await apiFetch<ShareLink[]>(`/replay/${leadId}/shares`);
       setLinks(data);
@@ -121,7 +130,8 @@ export function ShareDialog({ leadId, onClose }: ShareDialogProps) {
     try {
       await navigator.clipboard.writeText(buildShareUrl(token));
       setCopiedToken(token);
-      setTimeout(() => setCopiedToken(null), 2000);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopiedToken(null), 2000);
     } catch {
       // Fallback: select text for manual copy
       setError('Could not copy — please copy the URL manually');
@@ -140,6 +150,7 @@ export function ShareDialog({ leadId, onClose }: ShareDialogProps) {
         className="bg-th-bg-alt border border-th-border rounded-lg shadow-2xl w-full max-w-md flex flex-col"
         role="dialog"
         aria-label="Share session replay"
+        aria-modal="true"
       >
         {/* Header */}
         <div className="flex items-center gap-2 px-5 py-3 border-b border-th-border">

--- a/packages/web/src/components/Timeline/ShareDialog.tsx
+++ b/packages/web/src/components/Timeline/ShareDialog.tsx
@@ -24,20 +24,20 @@ const EXPIRY_OPTIONS = [
   { label: '24 hours', hours: 24 },
   { label: '7 days', hours: 168 },
   { label: '30 days', hours: 720 },
-  { label: 'Never', hours: 0 },
+  { label: 'Never', hours: 876_000 }, // ~100 years
 ] as const;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function formatExpiry(expiresAt: string): string {
   const exp = new Date(expiresAt);
-  if (exp.getFullYear() > 2099) return 'Never';
   const now = Date.now();
   const diffMs = exp.getTime() - now;
   if (diffMs <= 0) return 'Expired';
+  const days = Math.floor(diffMs / 86_400_000);
+  if (days > 365) return 'Never';
   const hours = Math.floor(diffMs / 3_600_000);
   if (hours < 24) return `${hours}h remaining`;
-  const days = Math.floor(hours / 24);
   return `${days}d remaining`;
 }
 
@@ -87,8 +87,7 @@ export function ShareDialog({ leadId, onClose }: ShareDialogProps) {
     setCreating(true);
     setError(null);
     try {
-      const body: Record<string, unknown> = {};
-      if (expiryHours > 0) body.expiresInHours = expiryHours;
+      const body: Record<string, unknown> = { expiresInHours: expiryHours };
       if (label.trim()) body.label = label.trim();
 
       const link = await apiFetch<ShareLink>(`/replay/${leadId}/share`, {

--- a/packages/web/src/components/Timeline/ShareDialog.tsx
+++ b/packages/web/src/components/Timeline/ShareDialog.tsx
@@ -1,0 +1,317 @@
+import { useState, useEffect, useCallback } from 'react';
+import { X, Link2, Copy, Check, Trash2, Plus, Clock, ExternalLink } from 'lucide-react';
+import { apiFetch } from '../../hooks/useApi';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface ShareLink {
+  token: string;
+  leadId: string;
+  createdAt: string;
+  expiresAt: string;
+  label?: string;
+  accessCount: number;
+}
+
+interface ShareDialogProps {
+  leadId: string;
+  onClose: () => void;
+}
+
+// ── Expiry options ───────────────────────────────────────────────────
+
+const EXPIRY_OPTIONS = [
+  { label: '24 hours', hours: 24 },
+  { label: '7 days', hours: 168 },
+  { label: '30 days', hours: 720 },
+  { label: 'Never', hours: 0 },
+] as const;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function formatExpiry(expiresAt: string): string {
+  const exp = new Date(expiresAt);
+  if (exp.getFullYear() > 2099) return 'Never';
+  const now = Date.now();
+  const diffMs = exp.getTime() - now;
+  if (diffMs <= 0) return 'Expired';
+  const hours = Math.floor(diffMs / 3_600_000);
+  if (hours < 24) return `${hours}h remaining`;
+  const days = Math.floor(hours / 24);
+  return `${days}d remaining`;
+}
+
+function buildShareUrl(token: string): string {
+  return `${window.location.origin}/shared/${token}`;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export function ShareDialog({ leadId, onClose }: ShareDialogProps) {
+  const [links, setLinks] = useState<ShareLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+  const [expiryHours, setExpiryHours] = useState(168); // default 7 days
+  const [label, setLabel] = useState('');
+
+  // ESC to close
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Fetch existing links
+  const fetchLinks = useCallback(async () => {
+    try {
+      const data = await apiFetch<ShareLink[]>(`/replay/${leadId}/shares`);
+      setLinks(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load share links');
+    } finally {
+      setLoading(false);
+    }
+  }, [leadId]);
+
+  useEffect(() => {
+    fetchLinks();
+  }, [fetchLinks]);
+
+  // Create share link
+  const handleCreate = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = {};
+      if (expiryHours > 0) body.expiresInHours = expiryHours;
+      if (label.trim()) body.label = label.trim();
+
+      const link = await apiFetch<ShareLink>(`/replay/${leadId}/share`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      setLinks((prev) => [link, ...prev]);
+      setLabel('');
+      // Auto-copy the new link
+      await copyToClipboard(link.token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create share link');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // Revoke share link
+  const handleRevoke = async (token: string) => {
+    try {
+      await apiFetch(`/shared/${token}`, { method: 'DELETE' });
+      setLinks((prev) => prev.filter((l) => l.token !== token));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to revoke link');
+    }
+  };
+
+  // Copy to clipboard
+  const copyToClipboard = async (token: string) => {
+    try {
+      await navigator.clipboard.writeText(buildShareUrl(token));
+      setCopiedToken(token);
+      setTimeout(() => setCopiedToken(null), 2000);
+    } catch {
+      // Fallback: select text for manual copy
+      setError('Could not copy — please copy the URL manually');
+    }
+  };
+
+  const activeLinks = links.filter((l) => new Date(l.expiresAt).getTime() > Date.now() || new Date(l.expiresAt).getFullYear() > 2099);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      data-testid="share-dialog-backdrop"
+    >
+      <div
+        className="bg-th-bg-alt border border-th-border rounded-lg shadow-2xl w-full max-w-md flex flex-col"
+        role="dialog"
+        aria-label="Share session replay"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-th-border">
+          <Link2 className="w-4 h-4 text-accent" aria-hidden="true" />
+          <h2 className="text-sm font-semibold text-th-text flex-1">Share Replay</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-th-text-muted hover:text-th-text transition-colors"
+            aria-label="Close share dialog"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-5 py-4 space-y-4 max-h-[calc(100vh-200px)] overflow-y-auto">
+          {error && (
+            <div className="text-xs text-red-400 bg-red-900/20 rounded px-3 py-2" data-testid="share-error">
+              {error}
+            </div>
+          )}
+
+          {/* Create new link */}
+          <div className="space-y-3">
+            <h3 className="text-xs font-medium text-th-text-muted uppercase tracking-wider">
+              Create Share Link
+            </h3>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Optional label..."
+                className="flex-1 text-sm bg-th-bg border border-th-border rounded px-3 py-1.5 text-th-text placeholder:text-th-text-muted focus:outline-none focus:border-accent"
+                data-testid="share-label-input"
+              />
+              <select
+                value={expiryHours}
+                onChange={(e) => setExpiryHours(Number(e.target.value))}
+                className="text-sm bg-th-bg border border-th-border rounded px-2 py-1.5 text-th-text focus:outline-none focus:border-accent"
+                data-testid="share-expiry-select"
+              >
+                {EXPIRY_OPTIONS.map((opt) => (
+                  <option key={opt.hours} value={opt.hours}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={handleCreate}
+              disabled={creating}
+              className="flex items-center gap-2 w-full justify-center px-3 py-2 text-sm rounded-lg bg-accent text-white hover:bg-accent/80 transition-colors disabled:opacity-50"
+              data-testid="share-create-btn"
+            >
+              <Plus size={14} aria-hidden="true" />
+              {creating ? 'Creating...' : 'Create Link'}
+            </button>
+          </div>
+
+          {/* Active links */}
+          <div className="space-y-2">
+            <h3 className="text-xs font-medium text-th-text-muted uppercase tracking-wider">
+              Active Links {activeLinks.length > 0 && `(${activeLinks.length})`}
+            </h3>
+
+            {loading ? (
+              <div className="text-xs text-th-text-muted text-center py-4" data-testid="share-loading">
+                Loading links...
+              </div>
+            ) : activeLinks.length === 0 ? (
+              <div className="text-xs text-th-text-muted text-center py-4" data-testid="share-empty">
+                No active share links
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {activeLinks.map((link) => (
+                  <ShareLinkRow
+                    key={link.token}
+                    link={link}
+                    copied={copiedToken === link.token}
+                    onCopy={() => copyToClipboard(link.token)}
+                    onRevoke={() => handleRevoke(link.token)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end px-5 py-3 border-t border-th-border">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm rounded-lg bg-th-bg-alt text-th-text-alt hover:bg-th-bg-muted hover:text-th-text transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── ShareLinkRow ─────────────────────────────────────────────────────
+
+function ShareLinkRow({
+  link,
+  copied,
+  onCopy,
+  onRevoke,
+}: {
+  link: ShareLink;
+  copied: boolean;
+  onCopy: () => void;
+  onRevoke: () => void;
+}) {
+  const url = buildShareUrl(link.token);
+
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-2 rounded bg-th-bg/50 border border-th-border"
+      data-testid="share-link-row"
+    >
+      <div className="flex-1 min-w-0">
+        {link.label && (
+          <span className="text-xs font-medium text-th-text-alt block truncate">
+            {link.label}
+          </span>
+        )}
+        <span className="text-[11px] text-th-text-muted block truncate font-mono">
+          {url}
+        </span>
+        <div className="flex items-center gap-3 mt-0.5">
+          <span className="text-[10px] text-th-text-muted flex items-center gap-1">
+            <Clock size={10} aria-hidden="true" />
+            {formatExpiry(link.expiresAt)}
+          </span>
+          {link.accessCount > 0 && (
+            <span className="text-[10px] text-th-text-muted">
+              {link.accessCount} view{link.accessCount !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+      </div>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="p-1 text-th-text-muted hover:text-accent transition-colors"
+        aria-label="Open shared replay"
+      >
+        <ExternalLink size={14} />
+      </a>
+      <button
+        onClick={onCopy}
+        className="p-1 text-th-text-muted hover:text-accent transition-colors"
+        aria-label={copied ? 'Link copied' : 'Copy share link'}
+        data-testid="share-copy-btn"
+      >
+        {copied ? <Check size={14} className="text-emerald-400" /> : <Copy size={14} />}
+      </button>
+      <button
+        onClick={onRevoke}
+        className="p-1 text-th-text-muted hover:text-red-400 transition-colors"
+        aria-label="Revoke share link"
+        data-testid="share-revoke-btn"
+      >
+        <Trash2 size={14} />
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/Timeline/TimelinePage.tsx
+++ b/packages/web/src/components/Timeline/TimelinePage.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useEffect, useRef, useCallback } from 'react';
-import { RefreshCw, Filter, Trash2 } from 'lucide-react';
+import { useMemo, useEffect, useRef, useCallback, useState } from 'react';
+import { RefreshCw, Filter, Trash2, Share2 } from 'lucide-react';
 import { useTimelineData } from './useTimelineData';
 import type { TimelineData, CommType, TimelineStatus } from './useTimelineData';
 import { TimelineContainer } from './TimelineContainer';
@@ -17,6 +17,7 @@ import { useSessionReplay } from '../../hooks/useSessionReplay';
 import { useProjects } from '../../hooks/useProjects';
 import { ProjectTabs } from '../ProjectTabs';
 import { useOptionalProjectId } from '../../contexts/ProjectContext';
+import { ShareDialog } from './ShareDialog';
 import './timeline-a11y.css';
 
 // ── Filter config ────────────────────────────────────────────────────
@@ -121,6 +122,9 @@ export function TimelinePage() {
 
   const getCachedData = useTimelineStore((s) => s.getCachedData);
   const clearCachedData = useTimelineStore((s) => s.clearCachedData);
+
+  // Share dialog state
+  const [showShareDialog, setShowShareDialog] = useState(false);
 
   // Lead selection — live agents and historical projects
   const leads = storeAgents.filter(a => !a.parentId || a.role?.id === 'lead');
@@ -376,6 +380,16 @@ export function TimelinePage() {
             <Trash2 size={14} aria-hidden="true" />
             Clear
           </button>
+          {effectiveLeadId && (
+            <button
+              onClick={() => setShowShareDialog(true)}
+              aria-label="Share session replay"
+              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-th-bg-alt text-th-text-alt hover:bg-th-bg-muted hover:text-th-text transition-colors"
+            >
+              <Share2 size={14} aria-hidden="true" />
+              Share
+            </button>
+          )}
         </div>
       </div>
 
@@ -474,6 +488,11 @@ export function TimelinePage() {
             onGoLive={() => setLiveMode(true)}
           />
         </div>
+      )}
+
+      {/* Share dialog */}
+      {showShareDialog && effectiveLeadId && (
+        <ShareDialog leadId={effectiveLeadId} onClose={() => setShowShareDialog(false)} />
       )}
     </div>
   );

--- a/packages/web/src/components/Timeline/__tests__/ShareDialog.test.tsx
+++ b/packages/web/src/components/Timeline/__tests__/ShareDialog.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockApiFetch = vi.fn();
+vi.mock('../../../hooks/useApi', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+// Stub clipboard API
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, {
+  clipboard: { writeText: mockWriteText },
+});
+
+import { ShareDialog } from '../ShareDialog';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const baseLink = {
+  token: 'abc-token-123',
+  leadId: 'lead-1',
+  createdAt: '2026-03-20T12:00:00Z',
+  expiresAt: '2026-12-31T00:00:00Z',
+  label: 'Demo link',
+  accessCount: 5,
+};
+
+const expiredLink = {
+  ...baseLink,
+  token: 'expired-token',
+  label: 'Old link',
+  expiresAt: '2020-01-01T00:00:00Z',
+  accessCount: 0,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('ShareDialog', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiFetch.mockReset();
+  });
+
+  it('renders dialog with create form', async () => {
+    mockApiFetch.mockResolvedValue([]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    expect(screen.getByText('Share Replay')).toBeInTheDocument();
+    expect(screen.getByText('Create Link')).toBeInTheDocument();
+    expect(screen.getByTestId('share-label-input')).toBeInTheDocument();
+    expect(screen.getByTestId('share-expiry-select')).toBeInTheDocument();
+  });
+
+  it('fetches existing share links on mount', async () => {
+    mockApiFetch.mockResolvedValue([baseLink]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/replay/lead-1/shares');
+    await waitFor(() => {
+      expect(screen.getByTestId('share-link-row')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no active links', async () => {
+    mockApiFetch.mockResolvedValue([]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('filters out expired links', async () => {
+    mockApiFetch.mockResolvedValue([expiredLink]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state', () => {
+    mockApiFetch.mockReturnValue(new Promise(() => {}));
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    expect(screen.getByTestId('share-loading')).toBeInTheDocument();
+  });
+
+  it('creates a share link and adds it to the list', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce([]) // initial fetch
+      .mockResolvedValueOnce(baseLink); // create
+
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    const createBtn = screen.getByTestId('share-create-btn');
+    await act(async () => {
+      fireEvent.click(createBtn);
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/replay/lead-1/share', expect.objectContaining({
+      method: 'POST',
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-link-row')).toBeInTheDocument();
+    });
+  });
+
+  it('sends label and expiry when creating', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce([]) // initial fetch
+      .mockResolvedValueOnce(baseLink); // create
+
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    // Type a label
+    const labelInput = screen.getByTestId('share-label-input');
+    fireEvent.change(labelInput, { target: { value: 'My demo' } });
+
+    // Change expiry to 24h
+    const expirySelect = screen.getByTestId('share-expiry-select');
+    fireEvent.change(expirySelect, { target: { value: '24' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-create-btn'));
+    });
+
+    const callBody = JSON.parse(mockApiFetch.mock.calls[1][1].body as string);
+    expect(callBody.label).toBe('My demo');
+    expect(callBody.expiresInHours).toBe(24);
+  });
+
+  it('copies link to clipboard on copy button click', async () => {
+    mockApiFetch.mockResolvedValue([baseLink]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await waitFor(() => screen.getByTestId('share-copy-btn'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-copy-btn'));
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith(
+      expect.stringContaining('/shared/abc-token-123'),
+    );
+  });
+
+  it('revokes a share link', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce([baseLink]) // initial fetch
+      .mockResolvedValueOnce({ revoked: true }); // delete
+
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await waitFor(() => screen.getByTestId('share-revoke-btn'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-revoke-btn'));
+    });
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/shared/abc-token-123', { method: 'DELETE' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('share-link-row')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error on fetch failure', async () => {
+    mockApiFetch.mockRejectedValue(new Error('Network error'));
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-error')).toBeInTheDocument();
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('closes on ESC key', async () => {
+    mockApiFetch.mockResolvedValue([]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on backdrop click', async () => {
+    mockApiFetch.mockResolvedValue([]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    const backdrop = screen.getByTestId('share-dialog-backdrop');
+    fireEvent.mouseDown(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Done button click', async () => {
+    mockApiFetch.mockResolvedValue([]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText('Done'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('displays link label and access count', async () => {
+    mockApiFetch.mockResolvedValue([baseLink]);
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByText('Demo link')).toBeInTheDocument();
+      expect(screen.getByText('5 views')).toBeInTheDocument();
+    });
+  });
+
+  it('auto-copies link after creation', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce([]) // initial fetch
+      .mockResolvedValueOnce(baseLink); // create
+
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-create-btn'));
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith(
+      expect.stringContaining('/shared/abc-token-123'),
+    );
+  });
+});

--- a/packages/web/src/components/Timeline/__tests__/ShareDialog.test.tsx
+++ b/packages/web/src/components/Timeline/__tests__/ShareDialog.test.tsx
@@ -140,6 +140,41 @@ describe('ShareDialog', () => {
     expect(callBody.expiresInHours).toBe(24);
   });
 
+  it('sends large expiresInHours for "Never" option', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce([]) // initial fetch
+      .mockResolvedValueOnce(baseLink); // create
+
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    const expirySelect = screen.getByTestId('share-expiry-select');
+    fireEvent.change(expirySelect, { target: { value: '876000' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-create-btn'));
+    });
+
+    const callBody = JSON.parse(mockApiFetch.mock.calls[1][1].body as string);
+    expect(callBody.expiresInHours).toBe(876000);
+  });
+
+  it('always sends expiresInHours with default value', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce([]) // initial fetch
+      .mockResolvedValueOnce(baseLink); // create
+
+    render(<ShareDialog leadId="lead-1" onClose={onClose} />);
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-create-btn'));
+    });
+
+    const callBody = JSON.parse(mockApiFetch.mock.calls[1][1].body as string);
+    expect(callBody.expiresInHours).toBe(168); // default 7 days
+  });
+
   it('copies link to clipboard on copy button click', async () => {
     mockApiFetch.mockResolvedValue([baseLink]);
     render(<ShareDialog leadId="lead-1" onClose={onClose} />);


### PR DESCRIPTION
Adds the Share UI for session replays — completing the viral sharing loop.

## Changes
- ShareDialog component (~220 LOC): create/copy/revoke share links, expiry settings (24h/7d/30d/Never)
- Share button in TimelinePage header
- Fixed: Never expiry now sends 876000h (~100y) instead of silently defaulting to 72h
- 17 tests

## Security
- Zero token leakage (no console logging, path-based tokens)
- CRUD through authenticated endpoints, shared view through token-validated endpoints

## Review
- Code ✅, Critical ✅, Readability ✅

Depends on PR #198 (Phase A).