### PR TITLE
fix: filter homepage activity feed to high-signal events (P0-2)

### DIFF
--- a/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
+++ b/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
@@ -280,11 +280,10 @@ export function HomeDashboard() {
     try {
       setLoading(true);
       setFetchError(null);
-      const [projectsData, decisionsData, progressData, completionData, pendingDecisionsData] = await Promise.all([
+      const [projectsData, decisionsData, progressData, pendingDecisionsData] = await Promise.all([
         apiFetch<EnrichedProject[]>('/projects').catch(() => []),
         apiFetch<Decision[]>('/decisions').catch(() => []),
-        apiFetch<ActivityEntry[]>('/coordination/activity?type=progress_update&limit=15').catch(() => []),
-        apiFetch<ActivityEntry[]>('/coordination/activity?type=task_completed&limit=15').catch(() => []),
+        apiFetch<ActivityEntry[]>('/coordination/activity?limit=50').catch(() => []),
         apiFetch<Decision[]>('/decisions?needs_confirmation=true').catch(() => []),
       ]);
 
@@ -298,11 +297,9 @@ export function HomeDashboard() {
       const pending = Array.isArray(pendingDecisionsData) ? pendingDecisionsData : [];
       useAppStore.getState().setPendingDecisions(pending);
 
-      // Merge progress updates and task completions (any agent), sort by timestamp
-      const progress = Array.isArray(progressData) ? progressData : [];
-      const completions = Array.isArray(completionData) ? completionData : [];
-      const merged = [...progress, ...completions]
-        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      // Filter to high-signal event types only — excludes noisy status_change, lock, message events
+      const merged = (Array.isArray(progressData) ? progressData : [])
+        .filter((a) => HIGH_SIGNAL_TYPES.has(a.actionType))
         .slice(0, 15);
       setRecentActivity(merged);
 

--- a/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
+++ b/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
@@ -46,6 +46,11 @@ import {
 import type { ActivityEntry } from '../Shared';
 import type { AgentInfo, Decision, DagStatus } from '../../types';
 
+// ── Constants ────────────────────────────────────────────────────────
+
+/** High-signal activity types for the homepage feed — excludes noisy status_change, lock, message events */
+const HIGH_SIGNAL_TYPES = new Set(['progress_update', 'task_completed', 'task_started', 'decision_made']);
+
 // ── Types ───────────────────────────────────────────────────────────
 
 /** Enriched project data from GET /api/projects */

--- a/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
+++ b/packages/web/src/components/HomeDashboard/HomeDashboard.tsx
@@ -285,7 +285,7 @@ export function HomeDashboard() {
     try {
       setLoading(true);
       setFetchError(null);
-      const [projectsData, decisionsData, progressData, pendingDecisionsData] = await Promise.all([
+      const [projectsData, decisionsData, activityData, pendingDecisionsData] = await Promise.all([
         apiFetch<EnrichedProject[]>('/projects').catch(() => []),
         apiFetch<Decision[]>('/decisions').catch(() => []),
         apiFetch<ActivityEntry[]>('/coordination/activity?limit=50').catch(() => []),
@@ -303,10 +303,10 @@ export function HomeDashboard() {
       useAppStore.getState().setPendingDecisions(pending);
 
       // Filter to high-signal event types only — excludes noisy status_change, lock, message events
-      const merged = (Array.isArray(progressData) ? progressData : [])
+      const highSignalActivity = (Array.isArray(activityData) ? activityData : [])
         .filter((a) => HIGH_SIGNAL_TYPES.has(a.actionType))
         .slice(0, 15);
-      setRecentActivity(merged);
+      setRecentActivity(highSignalActivity);
 
       // Fetch DAG progress for projects with active leads (parallelized)
       const dagPromises = activeProjects


### PR DESCRIPTION
Fixes noisy homepage activity feed by filtering to high-signal event types only.

## Changes
- Module-level HIGH_SIGNAL_TYPES constant: progress_update, task_completed, task_started, decision_made
- Single fetch (limit=50) + client-side type filter + display limit of 15
- Removed overly restrictive agentRole=lead filter — all agent activity now visible

## Note
This supersedes PR #195 (feat/task-completed-feed) which used a parallel two-fetch approach. This approach is simpler and more extensible.

## Review
- Code: ✅ Approved
- Critical: ✅ Approved (dead code fixed)
- Readability: ✅ Approved

32 tests pass.