### PR TITLE
fix: add scroll-to-top chat history pagination

### DIFF
--- a/packages/server/src/__tests__/AgentServices.test.ts
+++ b/packages/server/src/__tests__/AgentServices.test.ts
@@ -59,11 +59,11 @@ describe('AgentMessageService', () => {
       svc.bufferThinkingMessage('a1', 'thinking...');
       svc.persistHumanMessage('a1', 'user msg');
       const msgs = svc.getMessageHistory('a1');
-      // getMessageHistory returns newest-first; agent was flushed first, user last
+      // getMessageHistory returns oldest-first; agent was flushed first, user last
       expect(msgs).toHaveLength(3);
-      expect(msgs[0].sender).toBe('user');
+      expect(msgs[0].sender).toBe('agent');
       expect(msgs[1].sender).toBe('thinking');
-      expect(msgs[2].sender).toBe('agent');
+      expect(msgs[2].sender).toBe('user');
     });
 
     it('ignores messages for unknown threads', () => {
@@ -168,9 +168,9 @@ describe('AgentMessageService', () => {
 
       const msgs = svc.getMessageHistory('a1');
       expect(msgs).toHaveLength(2);
-      // newest-first: thinking was stored after agent
-      expect(msgs[0].sender).toBe('thinking');
-      expect(msgs[1].sender).toBe('agent');
+      // oldest-first: agent was stored before thinking
+      expect(msgs[0].sender).toBe('agent');
+      expect(msgs[1].sender).toBe('thinking');
     });
   });
 
@@ -195,14 +195,14 @@ describe('AgentMessageService', () => {
 
   // -- getMessageHistory ---------------------------------------------------
   describe('getMessageHistory', () => {
-    it('returns messages newest-first', () => {
+    it('returns messages oldest-first (chronological order)', () => {
       svc.createThread('a1');
       svc.persistSystemMessage('a1', 'first');
       svc.persistSystemMessage('a1', 'second');
       svc.persistSystemMessage('a1', 'third');
 
       const msgs = svc.getMessageHistory('a1');
-      expect(msgs.map((m) => m.content)).toEqual(['third', 'second', 'first']);
+      expect(msgs.map((m) => m.content)).toEqual(['first', 'second', 'third']);
     });
 
     it('returns empty array without a database', () => {

--- a/packages/server/src/__tests__/ConversationStore.test.ts
+++ b/packages/server/src/__tests__/ConversationStore.test.ts
@@ -149,4 +149,61 @@ describe('ConversationStore', () => {
       expect(messages[0].fromRole).toBe('Reviewer (def67890)');
     });
   });
+
+  describe('getMessagesBefore', () => {
+    it('returns messages older than the cursor ID', () => {
+      const thread = store.createThread('agent-1');
+      const m1 = store.addMessage(thread.id, 'user', 'First');
+      const m2 = store.addMessage(thread.id, 'agent', 'Second');
+      const m3 = store.addMessage(thread.id, 'user', 'Third');
+
+      // getMessagesBefore returns desc order (newest first) — caller reverses
+      const before = store.getMessagesBefore('agent-1', m3.id);
+      expect(before.length).toBe(2);
+      expect(before[0].content).toBe('Second');
+      expect(before[1].content).toBe('First');
+    });
+
+    it('respects the limit parameter', () => {
+      const thread = store.createThread('agent-1');
+      for (let i = 0; i < 10; i++) {
+        store.addMessage(thread.id, 'user', `Message ${i}`);
+      }
+      const allMsgs = store.getRecentMessages('agent-1', 100);
+      const lastId = allMsgs[0].id; // highest ID (desc order)
+
+      const before = store.getMessagesBefore('agent-1', lastId, 3);
+      expect(before.length).toBe(3);
+    });
+
+    it('returns empty array when no older messages exist', () => {
+      const thread = store.createThread('agent-1');
+      const m1 = store.addMessage(thread.id, 'user', 'Only message');
+
+      const before = store.getMessagesBefore('agent-1', m1.id);
+      expect(before.length).toBe(0);
+    });
+
+    it('does not return messages from other agents', () => {
+      const t1 = store.createThread('agent-1');
+      const t2 = store.createThread('agent-2');
+      store.addMessage(t1.id, 'user', 'Agent 1 msg');
+      store.addMessage(t2.id, 'user', 'Agent 2 msg');
+      const m3 = store.addMessage(t1.id, 'user', 'Agent 1 msg 2');
+
+      const before = store.getMessagesBefore('agent-1', m3.id);
+      expect(before.length).toBe(1);
+      expect(before[0].content).toBe('Agent 1 msg');
+    });
+
+    it('preserves fromRole in paginated results', () => {
+      const thread = store.createThread('agent-1');
+      store.addMessage(thread.id, 'external', 'DM content', 'Developer (abc12345)');
+      const m2 = store.addMessage(thread.id, 'agent', 'Response');
+
+      const before = store.getMessagesBefore('agent-1', m2.id);
+      expect(before.length).toBe(1);
+      expect(before[0].fromRole).toBe('Developer (abc12345)');
+    });
+  });
 });

--- a/packages/server/src/agents/AgentManager.ts
+++ b/packages/server/src/agents/AgentManager.ts
@@ -1229,6 +1229,11 @@ export class AgentManager extends TypedEmitter<AgentManagerEvents> {
     return this.messageService.getMessageHistory(agentId, limit);
   }
 
+  /** Get messages older than a cursor ID (for pagination). Returns oldest-first. */
+  getMessagesBefore(agentId: string, beforeId: number, limit = 50): import('../db/ConversationStore.js').ThreadMessage[] {
+    return this.messageService.getMessagesBefore(agentId, beforeId, limit);
+  }
+
   /**
    * Fail running DAG task assigned to an agent and notify the parent lead.
    * Shared by both onExit (crash path) and terminate (explicit kill path).

--- a/packages/server/src/agents/services/AgentMessageService.ts
+++ b/packages/server/src/agents/services/AgentMessageService.ts
@@ -64,6 +64,12 @@ export class AgentMessageService {
     return this.conversationStore.getRecentMessages(agentId, limit).reverse();
   }
 
+  /** Get messages older than a cursor ID (for pagination). Returns oldest-first. */
+  getMessagesBefore(agentId: string, beforeId: number, limit = 50): ThreadMessage[] {
+    if (!this.conversationStore) return [];
+    return this.conversationStore.getMessagesBefore(agentId, beforeId, limit).reverse();
+  }
+
   /** Buffer agent output text, flushing after 2s of silence */
   bufferAgentMessage(agentId: string, data: string): void {
     // Flush any pending thinking text first so messages stay chronological

--- a/packages/server/src/db/ConversationStore.ts
+++ b/packages/server/src/db/ConversationStore.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { eq, desc, asc } from 'drizzle-orm';
+import { eq, desc, asc, lt, and } from 'drizzle-orm';
 import type { Database } from '../db/database.js';
 import { conversations, messages } from '../db/schema.js';
 import { redact } from '../utils/redaction.js';
@@ -94,7 +94,37 @@ export class ConversationStore {
       .from(messages)
       .innerJoin(conversations, eq(messages.conversationId, conversations.id))
       .where(eq(conversations.agentId, agentId))
-      .orderBy(desc(messages.timestamp))
+      .orderBy(desc(messages.id))
+      .limit(limit)
+      .all();
+    return rows.map((r) => ({
+      id: r.id,
+      conversationId: r.conversationId,
+      sender: r.sender,
+      content: r.content,
+      fromRole: r.fromRole ?? undefined,
+      timestamp: r.timestamp!,
+    }));
+  }
+
+  /**
+   * Fetch messages older than a given cursor (message ID).
+   * Returns `limit` messages ordered newest-first (caller should reverse for display).
+   */
+  getMessagesBefore(agentId: string, beforeId: number, limit = 50): ThreadMessage[] {
+    const rows = this.db.drizzle
+      .select({
+        id: messages.id,
+        conversationId: messages.conversationId,
+        sender: messages.sender,
+        content: messages.content,
+        fromRole: messages.fromRole,
+        timestamp: messages.timestamp,
+      })
+      .from(messages)
+      .innerJoin(conversations, eq(messages.conversationId, conversations.id))
+      .where(and(eq(conversations.agentId, agentId), lt(messages.id, beforeId)))
+      .orderBy(desc(messages.id))
       .limit(limit)
       .all();
     return rows.map((r) => ({

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -188,13 +188,13 @@ export function agentsRoutes(ctx: AppContext): Router {
       }
     }
 
+    // hasMore: derived from pre-filter count so system message filtering can't hide it
+    const hasMore = messages.length >= limit;
+
     // Filter out system messages by default (they contain internal prompts/context)
     if (!includeSystem) {
       messages = messages.filter(m => m.sender !== 'system');
     }
-
-    // hasMore: true if we got a full page (may have more older messages)
-    const hasMore = messages.length >= limit;
 
     res.json({ agentId: resolvedAgentId, messages, fromPriorSession, hasMore });
   });

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -135,28 +135,54 @@ export function agentsRoutes(ctx: AppContext): Router {
   router.get('/agents/:id/messages', (req, res) => {
     const limit = Math.min(parseInt(String(req.query.limit) || '200', 10) || 200, 1000);
     const includeSystem = req.query.includeSystem === 'true';
+    const beforeId = req.query.before ? parseInt(String(req.query.before), 10) : undefined;
     const agentId = req.params.id as string;
 
-    // Get messages for this agent
-    let messages = agentManager.getMessageHistory(agentId, limit);
+    let messages: ReturnType<typeof agentManager.getMessageHistory>;
     let fromPriorSession = false;
+    let resolvedAgentId = agentId;
 
-    // For resumed sessions: also include messages from prior sessions of the same project
-    if (messages.length === 0 && ctx.projectRegistry) {
-      const agent = agentManager.get(agentId);
-      const projectId = agent?.projectId;
-      if (projectId) {
-        const sessions = ctx.projectRegistry.getSessions(projectId);
-        // Sessions are ordered by recency (newest first from getSessions)
-        const priorLeadIds = sessions
-          .map(s => s.leadId)
-          .filter(id => id !== agentId);
-        for (const leadId of priorLeadIds) {
-          const prior = agentManager.getMessageHistory(leadId, limit);
-          if (prior.length > 0) {
-            messages = prior;
-            fromPriorSession = true;
-            break;
+    if (beforeId != null && !isNaN(beforeId)) {
+      // Cursor-based pagination: get messages older than beforeId
+      messages = agentManager.getMessagesBefore(agentId, beforeId, limit);
+
+      // Try prior sessions if empty
+      if (messages.length === 0 && ctx.projectRegistry) {
+        const agent = agentManager.get(agentId);
+        const projectId = agent?.projectId;
+        if (projectId) {
+          const sessions = ctx.projectRegistry.getSessions(projectId);
+          const priorLeadIds = sessions.map(s => s.leadId).filter(id => id !== agentId);
+          for (const leadId of priorLeadIds) {
+            const prior = agentManager.getMessagesBefore(leadId, beforeId, limit);
+            if (prior.length > 0) {
+              messages = prior;
+              fromPriorSession = true;
+              resolvedAgentId = leadId;
+              break;
+            }
+          }
+        }
+      }
+    } else {
+      // Initial load: get most recent messages
+      messages = agentManager.getMessageHistory(agentId, limit);
+
+      // For resumed sessions: also include messages from prior sessions of the same project
+      if (messages.length === 0 && ctx.projectRegistry) {
+        const agent = agentManager.get(agentId);
+        const projectId = agent?.projectId;
+        if (projectId) {
+          const sessions = ctx.projectRegistry.getSessions(projectId);
+          const priorLeadIds = sessions.map(s => s.leadId).filter(id => id !== agentId);
+          for (const leadId of priorLeadIds) {
+            const prior = agentManager.getMessageHistory(leadId, limit);
+            if (prior.length > 0) {
+              messages = prior;
+              fromPriorSession = true;
+              resolvedAgentId = leadId;
+              break;
+            }
           }
         }
       }
@@ -167,7 +193,10 @@ export function agentsRoutes(ctx: AppContext): Router {
       messages = messages.filter(m => m.sender !== 'system');
     }
 
-    res.json({ agentId, messages, fromPriorSession });
+    // hasMore: true if we got a full page (may have more older messages)
+    const hasMore = messages.length >= limit;
+
+    res.json({ agentId: resolvedAgentId, messages, fromPriorSession, hasMore });
   });
 
   router.post('/agents/:id/input', validateBody(agentInputSchema), (req, res) => {

--- a/packages/web/src/components/LeadDashboard/ChatMessages.tsx
+++ b/packages/web/src/components/LeadDashboard/ChatMessages.tsx
@@ -105,6 +105,12 @@ interface ChatMessagesProps {
   catchUpSummary: CatchUpSummary | null;
   onDismissCatchUp: () => void;
   onScrollToBottom: () => void;
+  /** Called when user scrolls to the top — load older messages */
+  onLoadOlder?: () => void;
+  /** Whether there are more older messages to load */
+  hasMore?: boolean;
+  /** Whether older messages are currently being fetched */
+  loadingOlder?: boolean;
 }
 
 /** Context passed to Virtuoso Footer for the working indicator */
@@ -127,6 +133,9 @@ export function ChatMessages({
   catchUpSummary,
   onDismissCatchUp,
   onScrollToBottom,
+  onLoadOlder,
+  hasMore,
+  loadingOlder,
 }: ChatMessagesProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
@@ -234,16 +243,35 @@ export function ChatMessages({
     return isAtBottom ? 'smooth' : false;
   }, []);
 
+  // Stable firstItemIndex — allows Virtuoso to prepend items without scroll jump.
+  // We use a large base value so prepended items get lower indices.
+  const FIRST_ITEM_INDEX = 100_000;
+  const firstItemIndex = FIRST_ITEM_INDEX - items.length;
+
+  const handleStartReached = useCallback(() => {
+    if (hasMore && !loadingOlder && onLoadOlder) {
+      onLoadOlder();
+    }
+  }, [hasMore, loadingOlder, onLoadOlder]);
+
   return (
     <div className="flex-1 relative min-h-0">
+      {loadingOlder && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 px-3 py-1.5 rounded-full bg-th-bg-alt/90 border border-th-border/50 text-xs font-mono text-th-text-muted shadow-lg">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          Loading older messages…
+        </div>
+      )}
       <Virtuoso
         ref={virtuosoRef}
         className="absolute inset-0 [&>div]:p-4 [&>div]:space-y-1"
         data={items}
-        itemContent={itemContent}
+        firstItemIndex={firstItemIndex}
+        itemContent={(_index, item) => itemContent(_index, item)}
         context={context}
         components={{ Footer: ChatVirtuosoFooter }}
         followOutput={followOutput}
+        startReached={handleStartReached}
         increaseViewportBy={200}
         defaultItemHeight={32}
         overscan={200}

--- a/packages/web/src/components/LeadDashboard/ChatMessages.tsx
+++ b/packages/web/src/components/LeadDashboard/ChatMessages.tsx
@@ -267,7 +267,7 @@ export function ChatMessages({
         className="absolute inset-0 [&>div]:p-4 [&>div]:space-y-1"
         data={items}
         firstItemIndex={firstItemIndex}
-        itemContent={(_index, item) => itemContent(_index, item)}
+        itemContent={itemContent}
         context={context}
         components={{ Footer: ChatVirtuosoFooter }}
         followOutput={followOutput}

--- a/packages/web/src/components/LeadDashboard/LeadDashboard.tsx
+++ b/packages/web/src/components/LeadDashboard/LeadDashboard.tsx
@@ -122,7 +122,7 @@ export function LeadDashboard({ readOnly = false }: Props) {
   const { catchUpSummary, dismissCatchUp } = useCatchUpSummary(selectedLeadId, agents, currentProject);
 
   const chatInitialScroll = useRef(false);
-  useLeadMessages(selectedLeadId, readOnly, ws, chatInitialScroll);
+  const { hasMore, loadingOlder, loadOlderMessages } = useLeadMessages(selectedLeadId, readOnly, ws, chatInitialScroll);
 
   const isActiveAgent = selectedLeadId != null && !readOnly && isActive === true;
   useLeadPolling(selectedLeadId, isActiveAgent, historicalProjectId);
@@ -266,6 +266,9 @@ export function LeadDashboard({ readOnly = false }: Props) {
               catchUpSummary={catchUpSummary}
               onDismissCatchUp={dismissCatchUp}
               onScrollToBottom={handleScrollToBottom}
+              onLoadOlder={loadOlderMessages}
+              hasMore={hasMore}
+              loadingOlder={loadingOlder}
             />
 
             {readOnly ? (

--- a/packages/web/src/components/LeadDashboard/__tests__/LeadDashboard.test.tsx
+++ b/packages/web/src/components/LeadDashboard/__tests__/LeadDashboard.test.tsx
@@ -61,7 +61,9 @@ vi.mock('../../../hooks/useAttachments', () => ({
 vi.mock('../useLeadWebSocket', () => ({ useLeadWebSocket: vi.fn() }));
 vi.mock('../useDragResize', () => ({ useDragResize: () => vi.fn() }));
 vi.mock('../useLeadPolling', () => ({ useLeadPolling: vi.fn() }));
-vi.mock('../useLeadMessages', () => ({ useLeadMessages: vi.fn() }));
+vi.mock('../useLeadMessages', () => ({
+  useLeadMessages: vi.fn(() => ({ hasMore: false, loadingOlder: false, loadOlderMessages: vi.fn() })),
+}));
 vi.mock('../useCatchUpSummary', () => ({
   useCatchUpSummary: () => ({ catchUpSummary: null, dismissCatchUp: vi.fn() }),
 }));

--- a/packages/web/src/components/LeadDashboard/__tests__/useLeadMessages.test.ts
+++ b/packages/web/src/components/LeadDashboard/__tests__/useLeadMessages.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../../stores/leadStore', () => ({
 // ── Message store mock ──────────────────────────────────────────
 
 const mockMergeHistory = vi.fn();
+const mockPrependHistory = vi.fn();
 let mockChannels: Record<string, { messages: any[] }> = {};
 
 vi.mock('../../../stores/messageStore', () => ({
@@ -43,6 +44,7 @@ vi.mock('../../../stores/messageStore', () => ({
       getState: () => ({
         channels: mockChannels,
         mergeHistory: mockMergeHistory,
+        prependHistory: mockPrependHistory,
       }),
     },
   ),
@@ -283,5 +285,101 @@ describe('useLeadMessages', () => {
     await waitFor(() => {
       expect(mockMergeHistory).toHaveBeenCalledWith('lead-1', expect.any(Array));
     });
+  });
+
+  it('returns hasMore=true after initial load with full page', async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url.startsWith('/lead')) return Promise.resolve([]);
+      if (url.includes('/messages')) {
+        const msgs = Array.from({ length: 200 }, (_, i) => ({
+          id: i + 1,
+          content: `Msg ${i}`,
+          sender: 'agent',
+          timestamp: new Date(1000 + i).toISOString(),
+        }));
+        return Promise.resolve({ messages: msgs, hasMore: true });
+      }
+      return Promise.resolve({ messages: [] });
+    });
+
+    const { result } = renderHook(
+      () => useLeadMessages('lead-1', false, makeWs(), makeScrollRef()),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+  });
+
+  it('loadOlderMessages calls API with before cursor and prepends results', async () => {
+    let callCount = 0;
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url.startsWith('/lead')) return Promise.resolve([]);
+      if (url.includes('/messages') && url.includes('before=')) {
+        // Pagination request
+        return Promise.resolve({
+          messages: [
+            { id: 1, content: 'Old msg', sender: 'agent', timestamp: new Date(500).toISOString() },
+          ],
+          hasMore: false,
+        });
+      }
+      if (url.includes('/messages')) {
+        callCount++;
+        return Promise.resolve({
+          messages: [
+            { id: 10, content: 'Recent', sender: 'agent', timestamp: new Date(1000).toISOString() },
+          ],
+          hasMore: true,
+        });
+      }
+      return Promise.resolve({ messages: [] });
+    });
+
+    const { result } = renderHook(
+      () => useLeadMessages('lead-1', false, makeWs(), makeScrollRef()),
+      { wrapper: createWrapper() },
+    );
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Trigger load older
+    await act(async () => {
+      await result.current.loadOlderMessages();
+    });
+
+    expect(mockPrependHistory).toHaveBeenCalledWith('lead-1', expect.any(Array));
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('resets pagination state when switching leads', async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url.startsWith('/lead')) return Promise.resolve([]);
+      if (url.includes('/messages')) {
+        return Promise.resolve({
+          messages: [{ id: 5, content: 'Msg', sender: 'agent', timestamp: new Date(1000).toISOString() }],
+          hasMore: false,
+        });
+      }
+      return Promise.resolve({ messages: [] });
+    });
+
+    const { result, rerender } = renderHook(
+      ({ leadId }: { leadId: string | null }) =>
+        useLeadMessages(leadId, false, makeWs(), makeScrollRef()),
+      { wrapper: createWrapper(), initialProps: { leadId: 'lead-1' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+    });
+
+    // Switch lead — hasMore should reset to true
+    rerender({ leadId: 'lead-2' });
+    expect(result.current.hasMore).toBe(true);
   });
 });

--- a/packages/web/src/components/LeadDashboard/useLeadMessages.ts
+++ b/packages/web/src/components/LeadDashboard/useLeadMessages.ts
@@ -51,10 +51,14 @@ export function useLeadMessages(
   const [loadingOlder, setLoadingOlder] = useState(false);
   /** Oldest DB message ID we've seen — used as cursor for pagination */
   const oldestIdRef = useRef<number | null>(null);
+  /** Ref-based lock to prevent overlapping pagination requests (state is async) */
+  const loadingRef = useRef(false);
 
   // Reset pagination state when switching leads
   useEffect(() => {
     setHasMore(true);
+    setLoadingOlder(false);
+    loadingRef.current = false;
     oldestIdRef.current = null;
   }, [selectedLeadId]);
 
@@ -126,7 +130,8 @@ export function useLeadMessages(
 
   /** Load older messages (scroll-to-top pagination) */
   const loadOlderMessages = useCallback(async () => {
-    if (!selectedLeadId || !hasMore || loadingOlder || oldestIdRef.current == null) return;
+    if (!selectedLeadId || !hasMore || loadingRef.current || oldestIdRef.current == null) return;
+    loadingRef.current = true;
     setLoadingOlder(true);
     try {
       const data: MessageHistoryResponse = await apiFetch(
@@ -142,9 +147,10 @@ export function useLeadMessages(
     } catch {
       // Non-critical — user can retry by scrolling up again
     } finally {
+      loadingRef.current = false;
       setLoadingOlder(false);
     }
-  }, [selectedLeadId, hasMore, loadingOlder]);
+  }, [selectedLeadId, hasMore]);
 
   return { hasMore, loadingOlder, loadOlderMessages };
 }

--- a/packages/web/src/components/LeadDashboard/useLeadMessages.ts
+++ b/packages/web/src/components/LeadDashboard/useLeadMessages.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useLeadStore } from '../../stores/leadStore';
 import { useMessageStore } from '../../stores/messageStore';
@@ -8,11 +8,13 @@ import type { AcpTextChunk } from '../../types';
 /** Shape returned by /api/agents/:id/messages and /api/projects/:id/messages */
 interface MessageHistoryResponse {
   messages: Array<{
+    id?: number;
     content: string;
     sender: string;
     timestamp: string;
     fromRole?: string;
   }>;
+  hasMore?: boolean;
 }
 
 /** Shape returned by /api/lead — list of active lead agents */
@@ -23,9 +25,21 @@ interface LeadListItem {
   projectId?: string;
 }
 
+/** Convert server messages to AcpTextChunk with optional dbId */
+function toChunks(msgs: MessageHistoryResponse['messages']): (AcpTextChunk & { _dbId?: number })[] {
+  return msgs.map((m) => ({
+    type: 'text' as const,
+    text: m.content,
+    sender: m.sender as 'agent' | 'user' | 'system' | 'external' | 'thinking',
+    ...(m.fromRole ? { fromRole: m.fromRole } : {}),
+    timestamp: new Date(m.timestamp).getTime(),
+    _dbId: m.id,
+  }));
+}
+
 /**
  * Handles lead discovery on mount and message history loading for the selected lead.
- * Also manages WS subscription lifecycle.
+ * Also manages WS subscription lifecycle and scroll-to-top pagination.
  */
 export function useLeadMessages(
   selectedLeadId: string | null,
@@ -33,6 +47,16 @@ export function useLeadMessages(
   ws: { subscribe: (id: string) => void; unsubscribe: (id: string) => void },
   chatInitialScroll: React.MutableRefObject<boolean>,
 ) {
+  const [hasMore, setHasMore] = useState(true);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  /** Oldest DB message ID we've seen — used as cursor for pagination */
+  const oldestIdRef = useRef<number | null>(null);
+
+  // Reset pagination state when switching leads
+  useEffect(() => {
+    setHasMore(true);
+    oldestIdRef.current = null;
+  }, [selectedLeadId]);
 
   // On mount, load existing leads from server (skip in read-only mode — data pre-loaded)
   useQuery({
@@ -47,13 +71,7 @@ export function useLeadMessages(
         apiFetch<MessageHistoryResponse>(`/agents/${l.id}/messages?limit=200&includeSystem=true`, { signal })
           .then((data) => {
             if (Array.isArray(data?.messages) && data.messages.length > 0) {
-              const msgs: AcpTextChunk[] = data.messages.map((m) => ({
-                type: 'text' as const,
-                text: m.content,
-                sender: m.sender as 'agent' | 'user' | 'system' | 'thinking',
-                timestamp: new Date(m.timestamp).getTime(),
-              }));
-              useMessageStore.getState().mergeHistory(l.id, msgs);
+              useMessageStore.getState().mergeHistory(l.id, toChunks(data.messages));
             }
           })
           .catch(() => { /* non-critical — will load via WS */ });
@@ -93,18 +111,40 @@ export function useLeadMessages(
     queryFn: async ({ signal }) => {
       const data: MessageHistoryResponse = await apiFetch(msgApiPath, { signal });
       if (Array.isArray(data?.messages) && data.messages.length > 0) {
-        const msgs: AcpTextChunk[] = data.messages.map((m) => ({
-          type: 'text' as const,
-          text: m.content,
-          sender: m.sender as 'agent' | 'user' | 'system' | 'external' | 'thinking',
-          ...(m.fromRole ? { fromRole: m.fromRole } : {}),
-          timestamp: new Date(m.timestamp).getTime(),
-        }));
-        useMessageStore.getState().mergeHistory(selectedLeadId!, msgs);
+        const chunks = toChunks(data.messages);
+        useMessageStore.getState().mergeHistory(selectedLeadId!, chunks);
+        // Track oldest ID for cursor pagination
+        const ids = data.messages.map((m) => m.id).filter((id): id is number => id != null);
+        if (ids.length > 0) oldestIdRef.current = Math.min(...ids);
       }
+      setHasMore(data?.hasMore ?? false);
       return data;
     },
     enabled: needsHistory,
     staleTime: 60_000,
   });
+
+  /** Load older messages (scroll-to-top pagination) */
+  const loadOlderMessages = useCallback(async () => {
+    if (!selectedLeadId || !hasMore || loadingOlder || oldestIdRef.current == null) return;
+    setLoadingOlder(true);
+    try {
+      const data: MessageHistoryResponse = await apiFetch(
+        `/agents/${selectedLeadId}/messages?limit=50&before=${oldestIdRef.current}&includeSystem=true`,
+      );
+      if (Array.isArray(data?.messages) && data.messages.length > 0) {
+        const chunks = toChunks(data.messages);
+        useMessageStore.getState().prependHistory(selectedLeadId, chunks);
+        const ids = data.messages.map((m) => m.id).filter((id): id is number => id != null);
+        if (ids.length > 0) oldestIdRef.current = Math.min(...ids);
+      }
+      setHasMore(data?.hasMore ?? false);
+    } catch {
+      // Non-critical — user can retry by scrolling up again
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [selectedLeadId, hasMore, loadingOlder]);
+
+  return { hasMore, loadingOlder, loadOlderMessages };
 }

--- a/packages/web/src/stores/__tests__/messageStore.test.ts
+++ b/packages/web/src/stores/__tests__/messageStore.test.ts
@@ -504,4 +504,60 @@ describe('messageStore', () => {
       expect(s1).toBe(EMPTY_MESSAGES);
     });
   });
+
+  describe('prependHistory', () => {
+    it('prepends older messages before existing messages', () => {
+      const store = useMessageStore.getState();
+      store.addMessage(CH, { type: 'text', text: 'Msg 3', sender: 'agent', timestamp: 3000 });
+      store.addMessage(CH, { type: 'text', text: 'Msg 4', sender: 'agent', timestamp: 4000 });
+
+      store.prependHistory(CH, [
+        { type: 'text', text: 'Msg 1', sender: 'agent', timestamp: 1000 },
+        { type: 'text', text: 'Msg 2', sender: 'agent', timestamp: 2000 },
+      ]);
+
+      const msgs = useMessageStore.getState().channels[CH].messages;
+      expect(msgs.length).toBe(4);
+      expect(msgs[0].text).toBe('Msg 1');
+      expect(msgs[1].text).toBe('Msg 2');
+      expect(msgs[2].text).toBe('Msg 3');
+      expect(msgs[3].text).toBe('Msg 4');
+    });
+
+    it('deduplicates against existing messages', () => {
+      const store = useMessageStore.getState();
+      store.addMessage(CH, { type: 'text', text: 'Same msg', sender: 'agent', timestamp: 1000 });
+
+      store.prependHistory(CH, [
+        { type: 'text', text: 'Same msg', sender: 'agent', timestamp: 1000 },
+        { type: 'text', text: 'New msg', sender: 'agent', timestamp: 500 },
+      ]);
+
+      const msgs = useMessageStore.getState().channels[CH].messages;
+      expect(msgs.length).toBe(2);
+      expect(msgs[0].text).toBe('New msg');
+      expect(msgs[1].text).toBe('Same msg');
+    });
+
+    it('handles empty older array as no-op', () => {
+      const store = useMessageStore.getState();
+      store.addMessage(CH, { type: 'text', text: 'Existing', sender: 'agent', timestamp: 1000 });
+      const before = useMessageStore.getState().channels[CH];
+
+      store.prependHistory(CH, []);
+      const after = useMessageStore.getState().channels[CH];
+      expect(after).toBe(before); // Same reference — no state change
+    });
+
+    it('works on a non-existent channel', () => {
+      const store = useMessageStore.getState();
+      store.prependHistory('new-ch', [
+        { type: 'text', text: 'First', sender: 'agent', timestamp: 1000 },
+      ]);
+
+      const msgs = useMessageStore.getState().channels['new-ch'].messages;
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].text).toBe('First');
+    });
+  });
 });

--- a/packages/web/src/stores/messageStore.ts
+++ b/packages/web/src/stores/messageStore.ts
@@ -66,6 +66,9 @@ interface MessageStoreState {
   /** Merge history messages, deduplicating against existing */
   mergeHistory: (channelId: string, history: AcpTextChunk[]) => void;
 
+  /** Prepend older messages to the beginning of a channel (for pagination) */
+  prependHistory: (channelId: string, older: AcpTextChunk[]) => void;
+
   // ── Lifecycle ───────────────────────────────────────────────────
 
   /** Initialize a channel (no-op if exists) */
@@ -156,6 +159,21 @@ export const useMessageStore = create<MessageStoreState>((set, get) => ({
         return ts > latestHistTs || (ts >= latestHistTs && !histIds.has(messageId(m)));
       });
       const merged = [...history, ...liveOnly];
+      return {
+        channels: {
+          ...s.channels,
+          [channelId]: { ...ch, messages: merged, knownIds: buildIdSet(merged) },
+        },
+      };
+    }),
+
+  prependHistory: (channelId, older) =>
+    set((s) => {
+      const ch = s.channels[channelId] || emptyChannel();
+      // Filter out messages we already have
+      const newMsgs = older.filter((m) => !ch.knownIds.has(messageId(m)));
+      if (newMsgs.length === 0) return s;
+      const merged = [...newMsgs, ...ch.messages];
       return {
         channels: {
           ...s.channels,


### PR DESCRIPTION
## Problem
Chat history was truncated on page refresh — only the most recent messages were shown with no way to view older messages.

## Solution
Added cursor-based pagination that loads older messages as you scroll to the top.

### Server
- Added `getMessagesBefore()` to ConversationStore with cursor-based SQL query
- REST route accepts `?before=<messageId>&limit=50` with `hasMore` flag in response
- Works for both active and inactive sessions

### Client
- `prependHistory()` in messageStore for prepending older messages
- `useLeadMessages` hook exposes `loadOlderMessages/hasMore/loadingOlder`
- Virtuoso `startReached` + `firstItemIndex` for smooth scroll-to-top loading without position jumps

## Tests
12 new tests (5 server, 4 messageStore, 3 useLeadMessages). All tests passing. TypeScript compiles clean.

## Review
- Code review: ✅ Approved
- Critical review: ✅ Approved
- Readability review: ✅ Approved