### PR TITLE
fix: crew page Active filter should include idle agents

### DIFF
--- a/packages/web/src/components/CrewRoster/UnifiedCrewPage.tsx
+++ b/packages/web/src/components/CrewRoster/UnifiedCrewPage.tsx
@@ -143,11 +143,18 @@ function CrewGroup({ leadId, agents, summary, statusFilter, defaultExpanded = tr
     return a.role.localeCompare(b.role);
   });
 
+  // Effective status prefers real-time liveStatus over DB-persisted status
+  const effectiveStatus = (a: { status: RosterStatus; liveStatus: LiveStatus }): string =>
+    a.liveStatus ?? a.status;
+
   // Apply status filter to agent rows (crew header always shows)
   const visibleAgents = statusFilter === 'active'
-    ? sorted.filter(a => a.status !== 'terminated' && a.status !== 'failed')
+    ? sorted.filter(a => {
+        const s = effectiveStatus(a);
+        return s !== 'terminated' && s !== 'failed' && s !== 'completed';
+      })
     : statusFilter && statusFilter !== 'all'
-      ? sorted.filter(a => a.status === statusFilter)
+      ? sorted.filter(a => effectiveStatus(a) === statusFilter)
       : sorted;
 
   const lead = sorted.find(a => a.agentId === leadId || a.role === 'lead');

--- a/packages/web/src/components/CrewRoster/__tests__/UnifiedCrewPage.test.tsx
+++ b/packages/web/src/components/CrewRoster/__tests__/UnifiedCrewPage.test.tsx
@@ -495,6 +495,48 @@ describe('UnifiedCrewPage', () => {
     });
   });
 
+  it('Active filter includes idle agents, not just running', async () => {
+    mockProjectId = 'proj-1';
+    const agents = [
+      makeAgent({ agentId: 'lead-1', role: 'lead', liveStatus: 'running', status: 'running', teamId: 'lead-1', parentId: null }),
+      makeAgent({ agentId: 'running-1', role: 'developer', liveStatus: 'running', status: 'running', teamId: 'lead-1', parentId: 'lead-1' }),
+      makeAgent({ agentId: 'idle-1', role: 'architect', liveStatus: 'idle', status: 'idle', teamId: 'lead-1', parentId: 'lead-1' }),
+      makeAgent({ agentId: 'term-1', role: 'reviewer', liveStatus: 'terminated', status: 'terminated', teamId: 'lead-1', parentId: 'lead-1' }),
+    ];
+    setupApiMocks(agents);
+    renderPage({ scope: 'project' });
+
+    // Default filter is 'active' in project scope — should show running + idle
+    await waitFor(() => {
+      expect(screen.getByText('developer')).toBeInTheDocument();
+      expect(screen.getByText('architect')).toBeInTheDocument();
+    });
+
+    // Terminated agent should NOT appear under 'active' filter
+    expect(screen.queryByText('reviewer')).not.toBeInTheDocument();
+  });
+
+  it('Active filter uses liveStatus over DB status', async () => {
+    mockProjectId = 'proj-1';
+    const agents = [
+      makeAgent({ agentId: 'lead-1', role: 'lead', liveStatus: 'running', status: 'running', teamId: 'lead-1', parentId: null }),
+      // DB says running but live says terminated — should be filtered out
+      makeAgent({ agentId: 'stale-1', role: 'developer', liveStatus: 'terminated', status: 'running', teamId: 'lead-1', parentId: 'lead-1' }),
+      // DB says terminated but live says idle — should be shown
+      makeAgent({ agentId: 'revived-1', role: 'architect', liveStatus: 'idle', status: 'terminated', teamId: 'lead-1', parentId: 'lead-1' }),
+    ];
+    setupApiMocks(agents);
+    renderPage({ scope: 'project' });
+
+    // Default 'active' filter — liveStatus takes precedence
+    await waitFor(() => {
+      expect(screen.getByText('architect')).toBeInTheDocument();
+    });
+
+    // Stale agent with liveStatus=terminated should NOT appear
+    expect(screen.queryByText('developer')).not.toBeInTheDocument();
+  });
+
   // ─── Title & header ─────────────────────────────────────
 
   it('shows "Agents" title in global scope', async () => {


### PR DESCRIPTION
## Problem
The Crew page "Active" filter only showed running agents, excluding idle agents. The header correctly showed "18/18 active" but the filtered list only displayed running agents (e.g., 1-2 out of 18).

## Root Cause
The filter used the DB-persisted `status` field, which could be stale. Real-time `liveStatus` was not being consulted.

## Fix
Added `effectiveStatus()` helper that prefers `liveStatus` over stale DB `status` (using `??` fallback). Updated the Active filter to show all non-terminated/non-failed/non-completed agents.

## Tests
2 new tests: Active filter includes idle agents, liveStatus takes precedence over stale DB status.

## Stats
9 lines of production code + 2 tests. Triple reviewed (code ✅, critical ✅, readability ✅).