### PR TITLE
fix: cross-platform provider detection for Windows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# Cross-Platform Compatibility
+
+All code in this repository must work on Windows, macOS, and Linux.
+
+## Path Handling
+- Use `path.join()` or `path.resolve()` for file paths — never hardcode `/` or `\` separators.
+- Use `os.tmpdir()`, `os.homedir()` instead of hardcoded paths like `/tmp` or `~`.
+- Don't assume case-sensitive file systems.
+
+## Shell Commands
+- Never use Unix-only commands (`which`, `chmod`, `ln -s`) without providing a Windows equivalent.
+- For binary/command detection, use the shared `isBinaryAvailable()` from `utils/platform.ts`.
+- Use `process.platform === 'win32'` checks when platform-specific behavior is unavoidable.
+
+## Process Execution
+- Use `child_process.execFile()` instead of `exec()` with shell strings when possible — it's safer and more portable.
+- Prefer cross-platform npm packages over shell scripts.
+
+## Testing
+- Consider both forward slashes and backslashes in path handling.
+- Don't assume case-sensitive file systems.

--- a/packages/server/src/__tests__/AcpConnection.test.ts
+++ b/packages/server/src/__tests__/AcpConnection.test.ts
@@ -5,9 +5,14 @@ import { Writable, Readable } from 'stream';
 // ── Mock child_process ────────────────────────────────────────────
 const mockSpawn = vi.fn();
 const mockExecFileSync = vi.fn();
+const mockExecFile = vi.fn((_cmd: string, _args: string[], _opts: any, cb?: Function) => {
+  if (cb) cb(null, '', '');
+  return { on: vi.fn(), stdout: null, stderr: null };
+});
 vi.mock('child_process', () => ({
   spawn: (...args: any[]) => mockSpawn(...args),
   execFileSync: (...args: any[]) => mockExecFileSync(...args),
+  execFile: (...args: any[]) => mockExecFile(...args),
   ChildProcess: EventEmitter,
 }));
 

--- a/packages/server/src/__tests__/AcpConnection.test.ts
+++ b/packages/server/src/__tests__/AcpConnection.test.ts
@@ -5,14 +5,10 @@ import { Writable, Readable } from 'stream';
 // ── Mock child_process ────────────────────────────────────────────
 const mockSpawn = vi.fn();
 const mockExecFileSync = vi.fn();
-const mockExecFile = vi.fn((_cmd: string, _args: string[], _opts: any, cb?: Function) => {
-  if (cb) cb(null, '', '');
-  return { on: vi.fn(), stdout: null, stderr: null };
-});
 vi.mock('child_process', () => ({
   spawn: (...args: any[]) => mockSpawn(...args),
   execFileSync: (...args: any[]) => mockExecFileSync(...args),
-  execFile: (...args: any[]) => mockExecFile(...args),
+  execFile: vi.fn(),
   ChildProcess: EventEmitter,
 }));
 

--- a/packages/server/src/adapters/AcpAdapter.test.ts
+++ b/packages/server/src/adapters/AcpAdapter.test.ts
@@ -14,14 +14,10 @@ import { PassThrough } from 'stream';
 // ── Mock child_process ────────────────────────────────────────────
 const mockSpawn = vi.fn();
 const mockExecFileSync = vi.fn();
-const mockExecFile = vi.fn((_cmd: string, _args: string[], _opts: any, cb?: Function) => {
-  if (cb) cb(null, '', '');
-  return { on: vi.fn(), stdout: null, stderr: null };
-});
 vi.mock('child_process', () => ({
   spawn: (...args: any[]) => mockSpawn(...args),
   execFileSync: (...args: any[]) => mockExecFileSync(...args),
-  execFile: (...args: any[]) => mockExecFile(...args),
+  execFile: vi.fn(),
   ChildProcess: EventEmitter,
 }));
 

--- a/packages/server/src/adapters/AcpAdapter.test.ts
+++ b/packages/server/src/adapters/AcpAdapter.test.ts
@@ -14,9 +14,14 @@ import { PassThrough } from 'stream';
 // ── Mock child_process ────────────────────────────────────────────
 const mockSpawn = vi.fn();
 const mockExecFileSync = vi.fn();
+const mockExecFile = vi.fn((_cmd: string, _args: string[], _opts: any, cb?: Function) => {
+  if (cb) cb(null, '', '');
+  return { on: vi.fn(), stdout: null, stderr: null };
+});
 vi.mock('child_process', () => ({
   spawn: (...args: any[]) => mockSpawn(...args),
   execFileSync: (...args: any[]) => mockExecFileSync(...args),
+  execFile: (...args: any[]) => mockExecFile(...args),
   ChildProcess: EventEmitter,
 }));
 

--- a/packages/server/src/adapters/AcpAdapter.ts
+++ b/packages/server/src/adapters/AcpAdapter.ts
@@ -9,11 +9,11 @@
  * new interface boundary.
  */
 import { EventEmitter } from 'events';
-import { spawn, execFileSync, ChildProcess } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import { Readable, Writable } from 'stream';
 import * as acp from '@agentclientprotocol/sdk';
 import { logger } from '../utils/logger.js';
-import { WHICH_COMMAND } from '../utils/platform.js';
+import { isBinaryAvailableSync } from '../utils/platform.js';
 import type {
   AgentAdapter,
   AdapterStartOptions,
@@ -171,9 +171,7 @@ export class AcpAdapter extends EventEmitter implements AgentAdapter {
   }
 
   private validateCliCommand(command: string): void {
-    try {
-      execFileSync(WHICH_COMMAND, [command], { timeout: 3000, stdio: 'ignore' });
-    } catch {
+    if (!isBinaryAvailableSync(command)) {
       throw new Error(
         `CLI binary "${command}" not found in PATH. ` +
         `Install the provider CLI or set the binary path in your config.`,

--- a/packages/server/src/adapters/AcpAdapter.ts
+++ b/packages/server/src/adapters/AcpAdapter.ts
@@ -13,6 +13,7 @@ import { spawn, execFileSync, ChildProcess } from 'child_process';
 import { Readable, Writable } from 'stream';
 import * as acp from '@agentclientprotocol/sdk';
 import { logger } from '../utils/logger.js';
+import { WHICH_COMMAND } from '../utils/platform.js';
 import type {
   AgentAdapter,
   AdapterStartOptions,
@@ -171,8 +172,7 @@ export class AcpAdapter extends EventEmitter implements AgentAdapter {
 
   private validateCliCommand(command: string): void {
     try {
-      const checkCmd = process.platform === 'win32' ? 'where' : 'which';
-      execFileSync(checkCmd, [command], { timeout: 3000, stdio: 'ignore' });
+      execFileSync(WHICH_COMMAND, [command], { timeout: 3000, stdio: 'ignore' });
     } catch {
       throw new Error(
         `CLI binary "${command}" not found in PATH. ` +

--- a/packages/server/src/adapters/presets.ts
+++ b/packages/server/src/adapters/presets.ts
@@ -8,15 +8,11 @@
  * NOTE: Preset data is derived from the central ProviderRegistry in @flightdeck/shared.
  * To add a new provider, update the registry — presets are auto-generated.
  */
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import {
   PROVIDER_REGISTRY, PROVIDER_IDS,
   type ProviderId, type ProviderDefinition,
 } from '@flightdeck/shared';
-import { WHICH_COMMAND } from '../utils/platform.js';
-
-const execFileAsync = promisify(execFile);
+import { isBinaryAvailable } from '../utils/platform.js';
 
 // Re-export ProviderId from the shared registry (canonical source)
 export type { ProviderId } from '@flightdeck/shared';
@@ -89,19 +85,6 @@ export function listPresets(): ProviderPreset[] {
 export { isValidProviderId } from '@flightdeck/shared';
 
 // ── Detection ───────────────────────────────────────────────
-
-/**
- * Check if a binary is available on PATH.
- * Uses `which` on Unix, `where` on Windows.
- */
-async function isBinaryAvailable(binary: string): Promise<boolean> {
-  try {
-    await execFileAsync(WHICH_COMMAND, [binary], { timeout: 3000 });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /** Signature for the binary checker function used by detectInstalledProviders. */
 export type BinaryChecker = (binary: string) => Promise<boolean>;

--- a/packages/server/src/adapters/presets.ts
+++ b/packages/server/src/adapters/presets.ts
@@ -14,6 +14,7 @@ import {
   PROVIDER_REGISTRY, PROVIDER_IDS,
   type ProviderId, type ProviderDefinition,
 } from '@flightdeck/shared';
+import { WHICH_COMMAND } from '../utils/platform.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -94,9 +95,8 @@ export { isValidProviderId } from '@flightdeck/shared';
  * Uses `which` on Unix, `where` on Windows.
  */
 async function isBinaryAvailable(binary: string): Promise<boolean> {
-  const checkCmd = process.platform === 'win32' ? 'where' : 'which';
   try {
-    await execFileAsync(checkCmd, [binary], { timeout: 3000 });
+    await execFileAsync(WHICH_COMMAND, [binary], { timeout: 3000 });
     return true;
   } catch {
     return false;

--- a/packages/server/src/agents/Agent.ts
+++ b/packages/server/src/agents/Agent.ts
@@ -422,17 +422,6 @@ This codebase is worked on by AI agents as well as humans. Write code that is ea
 - Prefer explicit over implicit — avoid magic numbers, hidden side effects, and clever tricks
 - Define clear module boundaries with explicit exports
 
-== CROSS-PLATFORM COMPATIBILITY ==
-All code must work on Windows, macOS, and Linux:
-- Use path.join() or path.resolve() for file paths — never hardcode '/' or '\\' separators
-- Use process.platform === 'win32' checks when platform-specific behavior is unavoidable
-- Never use Unix-only commands (which, chmod, ln -s) without a Windows equivalent
-- For binary/command detection, use the shared isBinaryAvailable() from utils/platform.ts
-- Use os.tmpdir(), os.homedir() instead of hardcoded paths like /tmp or ~
-- Use 'node:child_process' execFile() instead of exec() with shell strings when possible
-- Test path handling with both forward and backslashes in mind
-- Prefer cross-platform npm packages over shell scripts
-
 == COLLABORATIVE DEBATE ==
 You are encouraged to challenge other agents' ideas and approaches — and to welcome challenges to your own. The goal is to reach the BEST decision, not to be right.
 - If you disagree with another agent's approach, say so respectfully and explain your reasoning. Use AGENT_MESSAGE to start a discussion.

--- a/packages/server/src/agents/Agent.ts
+++ b/packages/server/src/agents/Agent.ts
@@ -422,6 +422,17 @@ This codebase is worked on by AI agents as well as humans. Write code that is ea
 - Prefer explicit over implicit — avoid magic numbers, hidden side effects, and clever tricks
 - Define clear module boundaries with explicit exports
 
+== CROSS-PLATFORM COMPATIBILITY ==
+All code must work on Windows, macOS, and Linux:
+- Use path.join() or path.resolve() for file paths — never hardcode '/' or '\\' separators
+- Use process.platform === 'win32' checks when platform-specific behavior is unavoidable
+- Never use Unix-only commands (which, chmod, ln -s) without a Windows equivalent
+- For binary/command detection, use the shared isBinaryAvailable() from utils/platform.ts
+- Use os.tmpdir(), os.homedir() instead of hardcoded paths like /tmp or ~
+- Use 'node:child_process' execFile() instead of exec() with shell strings when possible
+- Test path handling with both forward and backslashes in mind
+- Prefer cross-platform npm packages over shell scripts
+
 == COLLABORATIVE DEBATE ==
 You are encouraged to challenge other agents' ideas and approaches — and to welcome challenges to your own. The goal is to reach the BEST decision, not to be right.
 - If you disagree with another agent's approach, say so respectfully and explain your reasoning. Use AGENT_MESSAGE to start a discussion.

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -18,6 +18,7 @@ import { promisify } from 'node:util';
 import type { Database } from '../db/database.js';
 import type { ConfigStore } from '../config/ConfigStore.js';
 import { PROVIDER_PRESETS, type ProviderId } from '../adapters/presets.js';
+import { WHICH_COMMAND } from '../utils/platform.js';
 import { PROVIDER_REGISTRY, PROVIDER_IDS } from '@flightdeck/shared';
 import { logger } from '../utils/logger.js';
 
@@ -139,7 +140,7 @@ export class ProviderManager {
     if (!preset) throw new Error(`Unknown provider: ${provider}`);
 
     try {
-      const path = this.exec(`which ${preset.binary}`);
+      const path = this.exec(`${WHICH_COMMAND} ${preset.binary}`);
       return { installed: true, binaryPath: path };
     } catch {
       return { installed: false, binaryPath: null };
@@ -211,7 +212,7 @@ export class ProviderManager {
     if (!preset) throw new Error(`Unknown provider: ${provider}`);
 
     try {
-      const path = await this.execAsync('which', [preset.binary]);
+      const path = await this.execAsync(WHICH_COMMAND, [preset.binary]);
       return { installed: true, binaryPath: path };
     } catch {
       return { installed: false, binaryPath: null };

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ProviderManager } from '../ProviderManager.js';
+import { WHICH_COMMAND } from '../../utils/platform.js';
 import type { Database } from '../../db/database.js';
 
 // ── Mock DB ──────────────────────────────────────────────────────
@@ -106,7 +107,7 @@ describe('ProviderManager', () => {
     it('uses correct binary name from preset', () => {
       exec.mockReturnValue('/usr/bin/agent');
       createManager().detectInstalled('cursor');
-      expect(exec).toHaveBeenCalledWith('which agent');
+      expect(exec).toHaveBeenCalledWith(`${WHICH_COMMAND} agent`);
     });
   });
 
@@ -190,7 +191,7 @@ describe('ProviderManager', () => {
       const result = await createManager().detectInstalledAsync('claude');
       expect(result.installed).toBe(true);
       expect(result.binaryPath).toBe('/usr/local/bin/claude');
-      expect(execAsync).toHaveBeenCalledWith('which', ['claude-agent-acp']);
+      expect(execAsync).toHaveBeenCalledWith(WHICH_COMMAND, ['claude-agent-acp']);
     });
 
     it('detects missing CLI binary', async () => {
@@ -295,7 +296,7 @@ describe('ProviderManager', () => {
 
       // which + version on first call only (2 calls); second call is cached
       const whichCalls = execAsync.mock.calls.filter(
-        (c: string[]) => c[0] === 'which',
+        (c: string[]) => c[0] === WHICH_COMMAND,
       );
       expect(whichCalls).toHaveLength(1);
     });
@@ -309,7 +310,7 @@ describe('ProviderManager', () => {
       await mgr.getProviderStatusAsync('claude');
 
       const whichCalls = execAsync.mock.calls.filter(
-        (c: string[]) => c[0] === 'which',
+        (c: string[]) => c[0] === WHICH_COMMAND,
       );
       expect(whichCalls).toHaveLength(2);
     });
@@ -324,7 +325,7 @@ describe('ProviderManager', () => {
 
       // Two rounds of `which` calls (8 providers each)
       const whichCalls = execAsync.mock.calls.filter(
-        (c: string[]) => c[0] === 'which',
+        (c: string[]) => c[0] === WHICH_COMMAND,
       );
       expect(whichCalls).toHaveLength(16);
     });
@@ -339,7 +340,7 @@ describe('ProviderManager', () => {
       await mgr.getProviderStatusAsync('claude');
 
       const whichCalls = execAsync.mock.calls.filter(
-        (c: string[]) => c[0] === 'which',
+        (c: string[]) => c[0] === WHICH_COMMAND,
       );
       expect(whichCalls).toHaveLength(2);
     });
@@ -414,7 +415,7 @@ describe('ProviderManager', () => {
 
       // Mock: claude binary is installed
       exec.mockImplementation((cmd: string) => {
-        if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
         throw new Error('not found');
       });
 
@@ -429,7 +430,7 @@ describe('ProviderManager', () => {
 
       // Mock: copilot binary is NOT installed, but claude is
       exec.mockImplementation((cmd: string) => {
-        if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
         throw new Error('not found');
       });
 
@@ -447,7 +448,7 @@ describe('ProviderManager', () => {
 
       // Mock: copilot is installed but disabled
       exec.mockImplementation((cmd: string) => {
-        if (cmd.startsWith('which ')) return '/usr/local/bin/some-binary';
+        if (cmd.startsWith(`${WHICH_COMMAND} `)) return '/usr/local/bin/some-binary';
         throw new Error('not found');
       });
 
@@ -478,7 +479,7 @@ describe('ProviderManager', () => {
 
       // Mock: only claude is installed
       exec.mockImplementation((cmd: string) => {
-        if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
         throw new Error('not found');
       });
 
@@ -510,7 +511,7 @@ describe('ProviderManager', () => {
     it('uses configured provider when installed (providers enabled by default)', () => {
       const configStore = createMockConfigStore({ providerId: 'claude' });
       exec.mockImplementation((cmd: string) => {
-        if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
         throw new Error('not found');
       });
 
@@ -524,7 +525,7 @@ describe('ProviderManager', () => {
       // has no explicit entry. isProviderEnabled should default to true.
       const configStore = createMockConfigStore({ providerId: 'claude', providerSettings: {} });
       exec.mockImplementation((cmd: string) => {
-        if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
         throw new Error('not found');
       });
 
@@ -539,7 +540,7 @@ describe('ProviderManager', () => {
         providerRanking: ['copilot', 'claude'],
       });
       exec.mockImplementation((cmd: string) => {
-        if (cmd.startsWith('which ')) return '/usr/local/bin/some-binary';
+        if (cmd.startsWith(`${WHICH_COMMAND} `)) return '/usr/local/bin/some-binary';
         throw new Error('not found');
       });
 
@@ -555,7 +556,7 @@ describe('ProviderManager', () => {
         providerRanking: ['copilot', 'claude', 'gemini'],
       });
       exec.mockImplementation((cmd: string) => {
-        if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
         throw new Error('not found');
       });
 
@@ -576,7 +577,7 @@ describe('ProviderManager', () => {
       // No DB, no configStore — only exec
       const mgr = new ProviderManager({
         execCommand: (cmd: string) => {
-          if (cmd === 'which claude-agent-acp') return '/usr/local/bin/claude-agent-acp';
+          if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
           throw new Error('not found');
         },
       });

--- a/packages/server/src/utils/platform.ts
+++ b/packages/server/src/utils/platform.ts
@@ -1,6 +1,36 @@
 /**
- * Cross-platform utility for binary detection.
+ * Cross-platform utilities for binary detection.
  *
  * Unix uses `which`, Windows uses `where` to check if a binary is on PATH.
+ * All binary detection should go through these helpers — no inline platform checks.
  */
+
+import { execFileSync, execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFileCb);
+
+/** Platform-appropriate command for locating binaries on PATH. */
 export const WHICH_COMMAND = process.platform === 'win32' ? 'where' : 'which';
+
+const BINARY_CHECK_TIMEOUT = 3_000;
+
+/** Check if a binary is available on PATH (async). */
+export async function isBinaryAvailable(binary: string): Promise<boolean> {
+  try {
+    await execFileAsync(WHICH_COMMAND, [binary], { timeout: BINARY_CHECK_TIMEOUT });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Check if a binary is available on PATH (sync). */
+export function isBinaryAvailableSync(binary: string): boolean {
+  try {
+    execFileSync(WHICH_COMMAND, [binary], { timeout: BINARY_CHECK_TIMEOUT, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/server/src/utils/platform.ts
+++ b/packages/server/src/utils/platform.ts
@@ -1,0 +1,6 @@
+/**
+ * Cross-platform utility for binary detection.
+ *
+ * Unix uses `which`, Windows uses `where` to check if a binary is on PATH.
+ */
+export const WHICH_COMMAND = process.platform === 'win32' ? 'where' : 'which';


### PR DESCRIPTION
## Problem
On Windows, provider detection fails because `which` (a Unix command) is hardcoded in `ProviderManager.ts`. All providers appear as "not installed" for Windows users.

## Fix
- Extracted a shared `WHICH_COMMAND` constant in `utils/platform.ts` that returns `"where"` on Windows and `"which"` on Unix
- Updated all 3 files that perform binary detection: `ProviderManager.ts` (both sync and async paths), `presets.ts`, and `AcpAdapter.ts`
- Consolidates 3 duplicate inline `process.platform` checks into one shared constant

## Files Changed
- `packages/server/src/utils/platform.ts` (new) — shared platform constant
- `packages/server/src/providers/ProviderManager.ts` — fixed both detection methods
- `packages/server/src/providers/presets.ts` — migrated to shared constant
- `packages/server/src/adapters/AcpAdapter.ts` — migrated to shared constant

## Testing
- Build passes
- Triple reviewed (code ✅, critical ✅, readability ✅)