### PR TITLE
feat: add claude-opus-4.7 model support

### DIFF
--- a/packages/server/src/adapters/ModelResolver.ts
+++ b/packages/server/src/adapters/ModelResolver.ts
@@ -79,6 +79,7 @@ function detectModelProvider(model: string): string {
 
 const EQUIVALENCES: Record<string, Record<string, string>> = {
   // Anthropic → others
+  'claude-opus-4.7': { openai: 'gpt-5.4', google: 'gemini-3.1-pro' },
   'claude-opus-4.6': { openai: 'gpt-5.2-codex', google: 'gemini-3.1-pro' },
   'claude-opus-4.5': { openai: 'gpt-5.1-codex-max', google: 'gemini-3.1-pro' },
   'claude-sonnet-4.6': { openai: 'gpt-5.3-codex', google: 'gemini-3.1-flash' },

--- a/packages/server/src/agents/ModelSelector.ts
+++ b/packages/server/src/agents/ModelSelector.ts
@@ -27,6 +27,14 @@ export const AVAILABLE_MODELS: ModelConfig[] = [
     bestFor: ['implementation', 'debugging', 'testing', 'analysis'],
   },
   {
+    id: 'claude-opus-4.7',
+    name: 'Claude Opus 4.7',
+    tier: 'premium',
+    contextWindow: 200000,
+    costPer1kTokens: 15.0,
+    bestFor: ['architecture', 'complex-debugging', 'design', 'critical-review'],
+  },
+  {
     id: 'claude-opus-4.6',
     name: 'Claude Opus 4.6',
     tier: 'premium',

--- a/packages/server/src/projects/ModelConfigDefaults.ts
+++ b/packages/server/src/projects/ModelConfigDefaults.ts
@@ -14,6 +14,7 @@ export type ProjectModelConfig = Record<string, string[]>;
  */
 export const KNOWN_MODEL_IDS: readonly string[] = [
   // Anthropic
+  'claude-opus-4.7',
   'claude-opus-4.6',
   'claude-opus-4.5',
   'claude-sonnet-4.6',

--- a/packages/web/src/constants/models.ts
+++ b/packages/web/src/constants/models.ts
@@ -10,6 +10,7 @@ export { deriveModelName } from '../hooks/useModels';
 /** @deprecated Use useModels() hook instead — this is a static fallback only */
 export const AVAILABLE_MODELS: string[] = [
   // Anthropic
+  'claude-opus-4.7',
   'claude-opus-4.6',
   'claude-opus-4.5',
   'claude-sonnet-4.6',


### PR DESCRIPTION
## Summary

Add claude-opus-4.7 as a selectable premium-tier model across the flightdeck stack.

## Changes

- **ModelSelector.ts**: Added claude-opus-4.7 to AVAILABLE_MODELS with premium tier metadata (cost, context window)
- **ModelConfigDefaults.ts**: Added to KNOWN_MODEL_IDS (feeds GET /models API → UI)
- **models.ts** (web): Added to static fallback model list
- **ModelResolver.ts**: Added cross-provider equivalences (openai: gpt-5.4, google: gemini-3.1-pro)

## Notes

- Defaults remain on claude-opus-4.6 — promoting opus-4.7 to default is a separate decision
- No breaking changes; opus-4.7 is additive only
- All 52 existing tests pass