### PR TITLE
Fix provider settings UI consistency on setup wizard branch

### DIFF
--- a/packages/server/src/__tests__/container.test.ts
+++ b/packages/server/src/__tests__/container.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { createContainer, createTestContainer, type ServiceContainer, type ContainerConfig } from '../container.js';
-import type { ServerConfig } from '../config.js';
+import { updateConfig, type ServerConfig } from '../config.js';
+import { ProviderManager } from '../providers/ProviderManager.js';
 import { logger } from '../utils/logger.js';
 
 // Mock config module so container's updateConfig/getConfig don't affect global state
@@ -251,6 +252,48 @@ describe('createContainer', () => {
     // because [...stopList].reverse() creates a copy each time
     expect(schedulerSpy).toHaveBeenCalledTimes(2);
     container = null;
+  });
+
+  it('keeps runtime config aligned when startup fallback rolls back after provider recovery', async () => {
+    const updateConfigMock = vi.mocked(updateConfig);
+    let activeProvider = 'claude';
+    const resolveSpy = vi.spyOn(ProviderManager.prototype, 'resolveAndPersistProvider').mockImplementation(() => activeProvider as any);
+    const getActiveSpy = vi.spyOn(ProviderManager.prototype, 'getActiveProviderId').mockImplementation(() => activeProvider as any);
+
+    try {
+      container = await createContainer(createTestContainerConfig());
+
+      expect(updateConfigMock).toHaveBeenCalledWith({
+        provider: 'claude',
+        providerBinaryOverride: undefined,
+        providerArgsOverride: undefined,
+        providerEnvOverride: undefined,
+        cloudProvider: undefined,
+      });
+
+      updateConfigMock.mockClear();
+
+      activeProvider = 'copilot';
+      container.internal.configStore.current.provider = {
+        id: 'copilot',
+        binaryOverride: '/custom/copilot',
+        argsOverride: ['--copilot-only'],
+        envOverride: { COPILOT_ONLY: '1' },
+      } as any;
+
+      container.providerManager?.emit('provider:runtime-changed');
+
+      expect(updateConfigMock).toHaveBeenCalledWith({
+        provider: 'copilot',
+        providerBinaryOverride: '/custom/copilot',
+        providerArgsOverride: ['--copilot-only'],
+        providerEnvOverride: { COPILOT_ONLY: '1' },
+        cloudProvider: undefined,
+      });
+    } finally {
+      resolveSpy.mockRestore();
+      getActiveSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/server/src/adapters/ModelResolver.test.ts
+++ b/packages/server/src/adapters/ModelResolver.test.ts
@@ -154,9 +154,9 @@ describe('ModelResolver', () => {
       expect(result.reason).toContain('equivalent');
     });
 
-    it('maps claude-opus-4.6 to gpt-5.2-codex on Codex', () => {
+    it('maps claude-opus-4.6 to gpt-5.4 on Codex', () => {
       const result = resolveModel('claude-opus-4.6', 'codex')!;
-      expect(result.model).toBe('gpt-5.2-codex');
+      expect(result.model).toBe('gpt-5.4');
       expect(result.translated).toBe(true);
     });
 
@@ -185,9 +185,9 @@ describe('ModelResolver', () => {
       expect(result.translated).toBe(true);
     });
 
-    it('maps gemini-3.1-pro to gpt-5.2-codex on Codex', () => {
+    it('maps gemini-3.1-pro to gpt-5.4 on Codex', () => {
       const result = resolveModel('gemini-3.1-pro', 'codex')!;
-      expect(result.model).toBe('gpt-5.2-codex');
+      expect(result.model).toBe('gpt-5.4');
       expect(result.translated).toBe(true);
     });
 
@@ -296,7 +296,7 @@ describe('ModelResolver', () => {
       expect(resolveModel('claude-opus-4.6', 'claude')?.model).toBe('opus');
       expect(resolveModel('claude-opus-4.6', 'gemini')?.model).toBe('gemini-3.1-pro');
       expect(resolveModel('claude-opus-4.6', 'cursor')?.model).toBe('claude-opus-4.6');
-      expect(resolveModel('claude-opus-4.6', 'codex')?.model).toBe('gpt-5.2-codex');
+      expect(resolveModel('claude-opus-4.6', 'codex')?.model).toBe('gpt-5.4');
       expect(resolveModel('claude-opus-4.6', 'opencode')?.model).toBe('anthropic/claude-opus-4.6');
     });
 

--- a/packages/server/src/adapters/ModelResolver.ts
+++ b/packages/server/src/adapters/ModelResolver.ts
@@ -80,7 +80,7 @@ function detectModelProvider(model: string): string {
 const EQUIVALENCES: Record<string, Record<string, string>> = {
   // Anthropic → others
   'claude-opus-4.7': { openai: 'gpt-5.4', google: 'gemini-3.1-pro' },
-  'claude-opus-4.6': { openai: 'gpt-5.2-codex', google: 'gemini-3.1-pro' },
+  'claude-opus-4.6': { openai: 'gpt-5.4', google: 'gemini-3.1-pro' },
   'claude-opus-4.5': { openai: 'gpt-5.1-codex-max', google: 'gemini-3.1-pro' },
   'claude-sonnet-4.6': { openai: 'gpt-5.3-codex', google: 'gemini-3.1-flash' },
   'claude-sonnet-4.5': { openai: 'gpt-5.3-codex', google: 'gemini-3.1-flash' },
@@ -101,9 +101,9 @@ const EQUIVALENCES: Record<string, Record<string, string>> = {
   'gpt-4.1': { anthropic: 'claude-sonnet-4', google: 'gemini-3.1-flash' },
 
   // Google → others
-  'gemini-3-pro-preview': { anthropic: 'claude-opus-4.6', openai: 'gpt-5.2-codex' },
+  'gemini-3-pro-preview': { anthropic: 'claude-opus-4.6', openai: 'gpt-5.4' },
   'gemini-3-flash-preview': { anthropic: 'claude-sonnet-4.6', openai: 'gpt-5.3-codex' },
-  'gemini-3.1-pro': { anthropic: 'claude-opus-4.6', openai: 'gpt-5.2-codex' },
+  'gemini-3.1-pro': { anthropic: 'claude-opus-4.6', openai: 'gpt-5.4' },
   'gemini-3.1-flash': { anthropic: 'claude-sonnet-4.6', openai: 'gpt-5.3-codex' },
   'gemini-3.1-flash-lite': { anthropic: 'claude-haiku-4.5', openai: 'gpt-5.1-codex-mini' },
 };

--- a/packages/server/src/container.ts
+++ b/packages/server/src/container.ts
@@ -121,6 +121,21 @@ export interface ServiceContainer extends AppContext {
   };
 }
 
+function syncRuntimeProviderConfig(providerManager: ProviderManager, configStore: ConfigStore): void {
+  const resolvedProvider = providerManager.getActiveProviderId();
+  if (resolvedProvider !== configStore.current.provider.id) {
+    updateConfig({
+      provider: resolvedProvider,
+      providerBinaryOverride: undefined,
+      providerArgsOverride: undefined,
+      providerEnvOverride: undefined,
+      cloudProvider: undefined,
+    });
+    return;
+  }
+  updateConfig(toProviderConfig(configStore.current.provider));
+}
+
 // ── Helpers ─────────────────────────────────────────────────
 
 /** Map YAML provider config to the flat ServerConfig fields. */
@@ -264,20 +279,9 @@ export async function createContainer(opts: ContainerConfig): Promise<ServiceCon
   // Resolve the best available provider at startup — if the configured provider
   // (from YAML or default 'copilot') isn't installed, fall back to the first
   // available one from the provider ranking.
-  const resolvedProvider = providerManager.resolveAndPersistProvider();
-  if (resolvedProvider !== configStore.current.provider.id) {
-    // Falling back to a different provider — clear YAML overrides so the
-    // original provider's binary/args/env/cloud settings don't bleed through.
-    updateConfig({
-      provider: resolvedProvider,
-      providerBinaryOverride: undefined,
-      providerArgsOverride: undefined,
-      providerEnvOverride: undefined,
-      cloudProvider: undefined,
-    });
-  } else {
-    updateConfig({ provider: resolvedProvider });
-  }
+  providerManager.resolveAndPersistProvider();
+  syncRuntimeProviderConfig(providerManager, configStore);
+  providerManager.on('provider:runtime-changed', () => syncRuntimeProviderConfig(providerManager, configStore));
 
   const skillsLoader = new SkillsLoader(join(repoRoot, '.github/skills'));
   skillsLoader.loadAll();
@@ -555,19 +559,8 @@ function wireEvents(c: ServiceContainer): void {
     updateConfig(toProviderConfig(providerCfg));
     // Re-resolve in case the new provider isn't installed
     if (c.providerManager) {
-      const resolved = c.providerManager.resolveAndPersistProvider();
-      if (resolved !== providerCfg.id) {
-        // Falling back — clear overrides from the unreachable provider
-        updateConfig({
-          provider: resolved,
-          providerBinaryOverride: undefined,
-          providerArgsOverride: undefined,
-          providerEnvOverride: undefined,
-          cloudProvider: undefined,
-        });
-      } else {
-        updateConfig({ provider: resolved });
-      }
+      c.providerManager.resolveAndPersistProvider();
+      syncRuntimeProviderConfig(c.providerManager, configStore);
     }
   });
 

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -97,6 +97,8 @@ export class ProviderManager {
 
   /** In-memory cache for CLI detection results (keyed by provider ID). */
   private readonly detectionCache = new Map<ProviderId, CachedDetection>();
+  /** Runtime fallback used while config-store persistence catches up or fails. */
+  private resolvedProviderOverride: ProviderId | null = null;
 
   /** Configurable TTL for testing. */
   readonly cacheTtlMs: number;
@@ -328,6 +330,26 @@ export class ProviderManager {
     return this.configStore ? this.configStore.current as FlightdeckConfig : null;
   }
 
+  private clearResolvedProviderOverrideIfAligned(providerId?: ProviderId): void {
+    if (!this.configStore || !this.resolvedProviderOverride) return;
+    if (providerId && this.resolvedProviderOverride !== providerId) return;
+    if (this.configStore.current.provider.id === this.resolvedProviderOverride) {
+      this.resolvedProviderOverride = null;
+    }
+  }
+
+  private buildProviderSwitchPatch(provider: ProviderId): { provider: Partial<FlightdeckConfig['provider']> } {
+    return {
+      provider: {
+        id: provider,
+        binaryOverride: undefined,
+        argsOverride: undefined,
+        envOverride: undefined,
+        cloudProvider: undefined,
+      },
+    };
+  }
+
   private applyConfigStorePatchAfterWrite(patch: {
     provider?: Partial<FlightdeckConfig['provider']>;
     providerSettings?: FlightdeckConfig['providerSettings'];
@@ -338,6 +360,9 @@ export class ProviderManager {
 
     if (patch.provider) {
       config.provider = { ...config.provider, ...patch.provider };
+      if (patch.provider.id) {
+        this.clearResolvedProviderOverrideIfAligned(patch.provider.id as ProviderId);
+      }
     }
     if (patch.providerSettings) {
       config.providerSettings = {
@@ -434,7 +459,7 @@ export class ProviderManager {
 
   getActiveProviderId(): ProviderId {
     if (this.configStore) {
-      return this.configStore.current.provider.id as ProviderId;
+      return this.resolvedProviderOverride ?? this.configStore.current.provider.id as ProviderId;
     }
     if (!this.db) return this.findFirstInstalledProvider();
     const raw = this.db.getSetting(`${SETTING_PREFIX}active`);
@@ -451,7 +476,9 @@ export class ProviderManager {
    * the active provider is actually usable.
    */
   resolveAndPersistProvider(): ProviderId {
-    const configured = this.getActiveProviderId();
+    const configured = this.configStore
+      ? this.configStore.current.provider.id as ProviderId
+      : this.getActiveProviderId();
 
     // Check if the configured provider is installed and enabled
     const { installed } = this.detectInstalled(configured);
@@ -466,8 +493,9 @@ export class ProviderManager {
     const fallbackProvider = this.findFirstUsableProvider(configured);
     if (fallbackProvider) {
       logger.info({ module: 'provider', msg: 'Falling back to available provider', from: configured, to: fallbackProvider });
+      this.resolvedProviderOverride = fallbackProvider;
       this.persistActiveProvider(fallbackProvider);
-      return this.configStore ? this.getActiveProviderId() : fallbackProvider;
+      return fallbackProvider;
     }
 
     // No provider found — keep the configured one and let downstream handle the error
@@ -504,7 +532,7 @@ export class ProviderManager {
 
   private persistActiveProvider(provider: ProviderId): void {
     if (this.configStore) {
-      const patch = { provider: { id: provider } } satisfies { provider: Partial<FlightdeckConfig['provider']> };
+      const patch = this.buildProviderSwitchPatch(provider);
       // Only update the provider id — don't spread the current provider config,
       // which may contain overrides (binary, args, env, cloud) for a different provider.
       this.configStore.writePartial(patch)
@@ -543,11 +571,14 @@ export class ProviderManager {
       const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
       const patch = {
         providerSettings: { [provider]: { ...current, enabled } },
-        ...(fallbackProvider ? { provider: { id: fallbackProvider } } : {}),
+        ...(fallbackProvider ? this.buildProviderSwitchPatch(fallbackProvider) : {}),
       } satisfies {
         providerSettings: FlightdeckConfig['providerSettings'];
         provider?: Partial<FlightdeckConfig['provider']>;
       };
+      if (fallbackProvider) {
+        this.resolvedProviderOverride = fallbackProvider;
+      }
       await this.configStore.writePartial(patch);
       this.applyConfigStorePatchAfterWrite(patch);
       return fallbackProvider ?? activeProvider;
@@ -568,7 +599,7 @@ export class ProviderManager {
     }
 
     if (this.configStore) {
-      const patch = { provider: { id: provider } } satisfies { provider: Partial<FlightdeckConfig['provider']> };
+      const patch = this.buildProviderSwitchPatch(provider);
       await this.configStore.writePartial(patch);
       this.applyConfigStorePatchAfterWrite(patch);
       return provider;

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -341,13 +341,28 @@ export class ProviderManager {
   }
 
   setProviderEnabled(provider: ProviderId, enabled: boolean): void {
+    const activeProvider = this.getActiveProviderId();
+    let fallbackProvider: ProviderId | null = null;
+    if (!enabled && activeProvider === provider) {
+      fallbackProvider = this.findFirstUsableProvider(provider);
+      if (!fallbackProvider) {
+        throw new Error(`Cannot disable active provider '${provider}' without another installed and enabled provider`);
+      }
+    }
+
     if (this.configStore) {
       const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
       this.configStore.writePartial({ providerSettings: { [provider]: { ...current, enabled } } }).catch(err => logger.warn({ msg: 'Failed to persist provider enabled state', provider, error: err }));
+      if (fallbackProvider) {
+        this.persistActiveProvider(fallbackProvider);
+      }
       return;
     }
     if (!this.db) return;
     this.db.setSetting(`${SETTING_PREFIX}${provider}:enabled`, String(enabled));
+    if (fallbackProvider) {
+      this.persistActiveProvider(fallbackProvider);
+    }
   }
 
   // ── Model Preferences ────────────────────────────────────
@@ -408,15 +423,11 @@ export class ProviderManager {
     logger.warn({ module: 'provider', msg: 'Configured provider not available, searching for fallback', provider: configured, installed });
 
     // Walk the provider ranking to find the first installed+enabled provider
-    const ranking = this.getProviderRanking();
-    for (const candidateId of ranking) {
-      if (candidateId === configured) continue; // already checked
-      const { installed: candidateInstalled } = this.detectInstalled(candidateId);
-      if (candidateInstalled && this.isProviderEnabled(candidateId)) {
-        logger.info({ module: 'provider', msg: 'Falling back to available provider', from: configured, to: candidateId });
-        this.setActiveProviderId(candidateId);
-        return candidateId;
-      }
+    const fallbackProvider = this.findFirstUsableProvider(configured);
+    if (fallbackProvider) {
+      logger.info({ module: 'provider', msg: 'Falling back to available provider', from: configured, to: fallbackProvider });
+      this.persistActiveProvider(fallbackProvider);
+      return fallbackProvider;
     }
 
     // No provider found — keep the configured one and let downstream handle the error
@@ -439,7 +450,19 @@ export class ProviderManager {
     return 'copilot'; // absolute last resort
   }
 
-  setActiveProviderId(provider: ProviderId): void {
+  private findFirstUsableProvider(excludeProvider?: ProviderId): ProviderId | null {
+    const ranking = this.getProviderRanking();
+    for (const candidateId of ranking) {
+      if (candidateId === excludeProvider) continue;
+      const { installed } = this.detectInstalled(candidateId);
+      if (installed && this.isProviderEnabled(candidateId)) {
+        return candidateId;
+      }
+    }
+    return null;
+  }
+
+  private persistActiveProvider(provider: ProviderId): void {
     if (this.configStore) {
       // Only update the provider id — don't spread the current provider config,
       // which may contain overrides (binary, args, env, cloud) for a different provider.
@@ -448,6 +471,19 @@ export class ProviderManager {
     }
     if (!this.db) return;
     this.db.setSetting(`${SETTING_PREFIX}active`, provider);
+  }
+
+  setActiveProviderId(provider: ProviderId): void {
+    if (!this.isProviderEnabled(provider)) {
+      throw new Error(`Provider '${provider}' is disabled`);
+    }
+
+    const { installed } = this.detectInstalled(provider);
+    if (!installed) {
+      throw new Error(`Provider '${provider}' is not installed`);
+    }
+
+    this.persistActiveProvider(provider);
   }
 
   // ── Provider Ranking ───────────────────────────────────────

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -17,6 +17,7 @@ import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { Database } from '../db/database.js';
 import type { ConfigStore } from '../config/ConfigStore.js';
+import type { FlightdeckConfig } from '../config/configSchema.js';
 import { PROVIDER_PRESETS, type ProviderId } from '../adapters/presets.js';
 import { WHICH_COMMAND } from '../utils/platform.js';
 import { PROVIDER_REGISTRY, PROVIDER_IDS } from '@flightdeck/shared';
@@ -323,6 +324,10 @@ export class ProviderManager {
 
   // ── Helpers ─────────────────────────────────────────────
 
+  private getMutableConfigStoreCurrent(): FlightdeckConfig | null {
+    return this.configStore ? this.configStore.current as FlightdeckConfig : null;
+  }
+
   /** Extract version-like pattern from CLI output. */
   private parseVersion(raw: string): string {
     const match = raw.match(/v?(\d+\.\d+(?:\.\d+)?(?:[-.]\w+)*)/);
@@ -351,11 +356,25 @@ export class ProviderManager {
     }
 
     if (this.configStore) {
+      const config = this.getMutableConfigStoreCurrent();
       const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
-      this.configStore.writePartial({ providerSettings: { [provider]: { ...current, enabled } } }).catch(err => logger.warn({ msg: 'Failed to persist provider enabled state', provider, error: err }));
-      if (fallbackProvider) {
-        this.persistActiveProvider(fallbackProvider);
+      const nextProviderSettings = { ...current, enabled };
+      if (config) {
+        config.providerSettings = {
+          ...config.providerSettings,
+          [provider]: nextProviderSettings,
+        };
+        if (fallbackProvider) {
+          config.provider = { ...config.provider, id: fallbackProvider };
+        }
       }
+      const patch: Record<string, unknown> = {
+        providerSettings: { [provider]: nextProviderSettings },
+      };
+      if (fallbackProvider) {
+        patch.provider = { id: fallbackProvider };
+      }
+      this.configStore.writePartial(patch).catch(err => logger.warn({ msg: 'Failed to persist provider enabled state', provider, error: err }));
       return;
     }
     if (!this.db) return;
@@ -380,9 +399,17 @@ export class ProviderManager {
 
   setModelPreferences(provider: ProviderId, prefs: ModelPreferences): void {
     if (this.configStore) {
+      const config = this.getMutableConfigStoreCurrent();
       const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
+      const nextModels = prefs.preferredModels ?? [];
+      if (config) {
+        config.providerSettings = {
+          ...config.providerSettings,
+          [provider]: { ...current, models: nextModels },
+        };
+      }
       this.configStore.writePartial({
-        providerSettings: { [provider]: { ...current, models: prefs.preferredModels ?? [] } },
+        providerSettings: { [provider]: { ...current, models: nextModels } },
       }).catch(err => logger.warn({ msg: 'Failed to persist model preferences', provider, error: err }));
       return;
     }
@@ -464,6 +491,10 @@ export class ProviderManager {
 
   private persistActiveProvider(provider: ProviderId): void {
     if (this.configStore) {
+      const config = this.getMutableConfigStoreCurrent();
+      if (config) {
+        config.provider = { ...config.provider, id: provider };
+      }
       // Only update the provider id — don't spread the current provider config,
       // which may contain overrides (binary, args, env, cloud) for a different provider.
       this.configStore.writePartial({ provider: { id: provider } }).catch(err => logger.warn({ msg: 'Failed to persist active provider', provider, error: err }));
@@ -510,6 +541,10 @@ export class ProviderManager {
 
   setProviderRanking(ranking: ProviderId[]): void {
     if (this.configStore) {
+      const config = this.getMutableConfigStoreCurrent();
+      if (config) {
+        config.providerRanking = ranking;
+      }
       this.configStore.writePartial({ providerRanking: ranking }).catch(err =>
         logger.warn({ msg: 'Failed to persist provider ranking', error: err }),
       );

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -366,6 +366,7 @@ export class ProviderManager extends EventEmitter {
   private rollbackResolvedProviderOverride(configuredProviderId?: ProviderId): void {
     this.resolvedProviderOverride = null;
     this.failedProviderPersistenceConfiguredId = configuredProviderId ?? null;
+    this.emit('provider:runtime-changed');
   }
 
   private shouldSuppressFallback(configuredProviderId: ProviderId): boolean {

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -451,7 +451,7 @@ export class ProviderManager extends EventEmitter {
         provider?: Partial<FlightdeckConfig['provider']>;
       };
       if (fallbackProvider) {
-        patch.provider = { id: fallbackProvider };
+        patch.provider = this.buildProviderSwitchPatch(fallbackProvider).provider;
       }
       this.configStore.writePartial(patch)
         .then(() => this.applyConfigStorePatchAfterWrite(patch))

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -328,6 +328,28 @@ export class ProviderManager {
     return this.configStore ? this.configStore.current as FlightdeckConfig : null;
   }
 
+  private applyConfigStorePatchAfterWrite(patch: {
+    provider?: Partial<FlightdeckConfig['provider']>;
+    providerSettings?: FlightdeckConfig['providerSettings'];
+    providerRanking?: FlightdeckConfig['providerRanking'];
+  }): void {
+    const config = this.getMutableConfigStoreCurrent();
+    if (!config) return;
+
+    if (patch.provider) {
+      config.provider = { ...config.provider, ...patch.provider };
+    }
+    if (patch.providerSettings) {
+      config.providerSettings = {
+        ...config.providerSettings,
+        ...patch.providerSettings,
+      };
+    }
+    if (patch.providerRanking) {
+      config.providerRanking = patch.providerRanking;
+    }
+  }
+
   /** Extract version-like pattern from CLI output. */
   private parseVersion(raw: string): string {
     const match = raw.match(/v?(\d+\.\d+(?:\.\d+)?(?:[-.]\w+)*)/);
@@ -356,25 +378,20 @@ export class ProviderManager {
     }
 
     if (this.configStore) {
-      const config = this.getMutableConfigStoreCurrent();
       const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
       const nextProviderSettings = { ...current, enabled };
-      if (config) {
-        config.providerSettings = {
-          ...config.providerSettings,
-          [provider]: nextProviderSettings,
-        };
-        if (fallbackProvider) {
-          config.provider = { ...config.provider, id: fallbackProvider };
-        }
-      }
-      const patch: Record<string, unknown> = {
+      const patch = {
         providerSettings: { [provider]: nextProviderSettings },
+      } as {
+        providerSettings: FlightdeckConfig['providerSettings'];
+        provider?: Partial<FlightdeckConfig['provider']>;
       };
       if (fallbackProvider) {
         patch.provider = { id: fallbackProvider };
       }
-      this.configStore.writePartial(patch).catch(err => logger.warn({ msg: 'Failed to persist provider enabled state', provider, error: err }));
+      this.configStore.writePartial(patch)
+        .then(() => this.applyConfigStorePatchAfterWrite(patch))
+        .catch(err => logger.warn({ msg: 'Failed to persist provider enabled state', provider, error: err }));
       return;
     }
     if (!this.db) return;
@@ -399,18 +416,14 @@ export class ProviderManager {
 
   setModelPreferences(provider: ProviderId, prefs: ModelPreferences): void {
     if (this.configStore) {
-      const config = this.getMutableConfigStoreCurrent();
       const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
       const nextModels = prefs.preferredModels ?? [];
-      if (config) {
-        config.providerSettings = {
-          ...config.providerSettings,
-          [provider]: { ...current, models: nextModels },
-        };
-      }
-      this.configStore.writePartial({
+      const patch = {
         providerSettings: { [provider]: { ...current, models: nextModels } },
-      }).catch(err => logger.warn({ msg: 'Failed to persist model preferences', provider, error: err }));
+      } satisfies { providerSettings: FlightdeckConfig['providerSettings'] };
+      this.configStore.writePartial(patch)
+        .then(() => this.applyConfigStorePatchAfterWrite(patch))
+        .catch(err => logger.warn({ msg: 'Failed to persist model preferences', provider, error: err }));
       return;
     }
     if (!this.db) return;
@@ -491,13 +504,12 @@ export class ProviderManager {
 
   private persistActiveProvider(provider: ProviderId): void {
     if (this.configStore) {
-      const config = this.getMutableConfigStoreCurrent();
-      if (config) {
-        config.provider = { ...config.provider, id: provider };
-      }
+      const patch = { provider: { id: provider } } satisfies { provider: Partial<FlightdeckConfig['provider']> };
       // Only update the provider id — don't spread the current provider config,
       // which may contain overrides (binary, args, env, cloud) for a different provider.
-      this.configStore.writePartial({ provider: { id: provider } }).catch(err => logger.warn({ msg: 'Failed to persist active provider', provider, error: err }));
+      this.configStore.writePartial(patch)
+        .then(() => this.applyConfigStorePatchAfterWrite(patch))
+        .catch(err => logger.warn({ msg: 'Failed to persist active provider', provider, error: err }));
       return;
     }
     if (!this.db) return;
@@ -515,6 +527,55 @@ export class ProviderManager {
     }
 
     this.persistActiveProvider(provider);
+  }
+
+  async setProviderEnabledPersisted(provider: ProviderId, enabled: boolean): Promise<ProviderId> {
+    const activeProvider = this.getActiveProviderId();
+    let fallbackProvider: ProviderId | null = null;
+    if (!enabled && activeProvider === provider) {
+      fallbackProvider = this.findFirstUsableProvider(provider);
+      if (!fallbackProvider) {
+        throw new Error(`Cannot disable active provider '${provider}' without another installed and enabled provider`);
+      }
+    }
+
+    if (this.configStore) {
+      const current = this.configStore.current.providerSettings[provider] ?? { enabled: true, models: [] };
+      const patch = {
+        providerSettings: { [provider]: { ...current, enabled } },
+        ...(fallbackProvider ? { provider: { id: fallbackProvider } } : {}),
+      } satisfies {
+        providerSettings: FlightdeckConfig['providerSettings'];
+        provider?: Partial<FlightdeckConfig['provider']>;
+      };
+      await this.configStore.writePartial(patch);
+      this.applyConfigStorePatchAfterWrite(patch);
+      return fallbackProvider ?? activeProvider;
+    }
+
+    this.setProviderEnabled(provider, enabled);
+    return this.getActiveProviderId();
+  }
+
+  async setActiveProviderIdPersisted(provider: ProviderId): Promise<ProviderId> {
+    if (!this.isProviderEnabled(provider)) {
+      throw new Error(`Provider '${provider}' is disabled`);
+    }
+
+    const { installed } = this.detectInstalled(provider);
+    if (!installed) {
+      throw new Error(`Provider '${provider}' is not installed`);
+    }
+
+    if (this.configStore) {
+      const patch = { provider: { id: provider } } satisfies { provider: Partial<FlightdeckConfig['provider']> };
+      await this.configStore.writePartial(patch);
+      this.applyConfigStorePatchAfterWrite(patch);
+      return provider;
+    }
+
+    this.persistActiveProvider(provider);
+    return provider;
   }
 
   // ── Provider Ranking ───────────────────────────────────────
@@ -541,13 +602,10 @@ export class ProviderManager {
 
   setProviderRanking(ranking: ProviderId[]): void {
     if (this.configStore) {
-      const config = this.getMutableConfigStoreCurrent();
-      if (config) {
-        config.providerRanking = ranking;
-      }
-      this.configStore.writePartial({ providerRanking: ranking }).catch(err =>
-        logger.warn({ msg: 'Failed to persist provider ranking', error: err }),
-      );
+      const patch = { providerRanking: ranking } satisfies { providerRanking: FlightdeckConfig['providerRanking'] };
+      this.configStore.writePartial(patch)
+        .then(() => this.applyConfigStorePatchAfterWrite(patch))
+        .catch(err => logger.warn({ msg: 'Failed to persist provider ranking', error: err }));
       return;
     }
     if (!this.db) return;

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -99,6 +99,10 @@ export class ProviderManager {
   private readonly detectionCache = new Map<ProviderId, CachedDetection>();
   /** Runtime fallback used while config-store persistence catches up or fails. */
   private resolvedProviderOverride: ProviderId | null = null;
+  /** Configured provider whose fallback write most recently failed. */
+  private failedProviderPersistenceConfiguredId: ProviderId | null = null;
+  /** Monotonic guard against stale async provider writes applying after reload/recovery. */
+  private providerResolutionVersion = 0;
 
   /** Configurable TTL for testing. */
   readonly cacheTtlMs: number;
@@ -121,6 +125,11 @@ export class ProviderManager {
       return stdout.trim();
     });
     this.cacheTtlMs = opts.cacheTtlMs ?? CACHE_TTL_MS;
+
+    if (this.configStore) {
+      this.configStore.on('config:provider:changed', () => this.resetRuntimeProviderResolution());
+      this.configStore.on('config:reloaded', () => this.resetRuntimeProviderResolution());
+    }
   }
 
   // ── Config (instant, no CLI calls) ──────────────────────
@@ -330,10 +339,38 @@ export class ProviderManager {
     return this.configStore ? this.configStore.current as FlightdeckConfig : null;
   }
 
+  private resetRuntimeProviderResolution(): void {
+    this.providerResolutionVersion += 1;
+    this.resolvedProviderOverride = null;
+    this.failedProviderPersistenceConfiguredId = null;
+  }
+
+  private beginProviderResolutionTransition(): number {
+    this.providerResolutionVersion += 1;
+    return this.providerResolutionVersion;
+  }
+
+  private isCurrentProviderResolutionTransition(version: number): boolean {
+    return this.providerResolutionVersion === version;
+  }
+
   private clearResolvedProviderOverride(providerId?: ProviderId): void {
     if (!this.configStore || !this.resolvedProviderOverride) return;
     if (providerId && this.configStore.current.provider.id !== providerId) return;
+    this.resetRuntimeProviderResolution();
+  }
+
+  private rollbackResolvedProviderOverride(configuredProviderId?: ProviderId): void {
     this.resolvedProviderOverride = null;
+    this.failedProviderPersistenceConfiguredId = configuredProviderId ?? null;
+  }
+
+  private shouldSuppressFallback(configuredProviderId: ProviderId): boolean {
+    return Boolean(
+      this.configStore &&
+      this.failedProviderPersistenceConfiguredId === configuredProviderId &&
+      this.configStore.current.provider.id === configuredProviderId,
+    );
   }
 
   private buildProviderSwitchPatch(provider: ProviderId): { provider: Partial<FlightdeckConfig['provider']> } {
@@ -487,12 +524,18 @@ export class ProviderManager {
 
     logger.warn({ module: 'provider', msg: 'Configured provider not available, searching for fallback', provider: configured, installed });
 
+    if (this.shouldSuppressFallback(configured)) {
+      logger.warn({ module: 'provider', msg: 'Skipping fallback after failed provider persistence until config changes', provider: configured });
+      return configured;
+    }
+
     // Walk the provider ranking to find the first installed+enabled provider
     const fallbackProvider = this.findFirstUsableProvider(configured);
     if (fallbackProvider) {
       logger.info({ module: 'provider', msg: 'Falling back to available provider', from: configured, to: fallbackProvider });
+      const transitionVersion = this.beginProviderResolutionTransition();
       this.resolvedProviderOverride = fallbackProvider;
-      this.persistActiveProvider(fallbackProvider);
+      this.persistActiveProvider(fallbackProvider, configured, transitionVersion);
       return fallbackProvider;
     }
 
@@ -528,14 +571,23 @@ export class ProviderManager {
     return null;
   }
 
-  private persistActiveProvider(provider: ProviderId): void {
+  private persistActiveProvider(provider: ProviderId, configuredProviderId?: ProviderId, transitionVersion?: number): void {
     if (this.configStore) {
       const patch = this.buildProviderSwitchPatch(provider);
+      const version = transitionVersion ?? this.beginProviderResolutionTransition();
       // Only update the provider id — don't spread the current provider config,
       // which may contain overrides (binary, args, env, cloud) for a different provider.
       this.configStore.writePartial(patch)
-        .then(() => this.applyConfigStorePatchAfterWrite(patch))
-        .catch(err => logger.warn({ msg: 'Failed to persist active provider', provider, error: err }));
+        .then(() => {
+          if (!this.isCurrentProviderResolutionTransition(version)) return;
+          this.applyConfigStorePatchAfterWrite(patch);
+        })
+        .catch(err => {
+          if (this.isCurrentProviderResolutionTransition(version)) {
+            this.rollbackResolvedProviderOverride(configuredProviderId);
+          }
+          logger.warn({ msg: 'Failed to persist active provider', provider, error: err });
+        });
       return;
     }
     if (!this.db) return;
@@ -574,12 +626,23 @@ export class ProviderManager {
         providerSettings: FlightdeckConfig['providerSettings'];
         provider?: Partial<FlightdeckConfig['provider']>;
       };
+      const transitionVersion = fallbackProvider ? this.beginProviderResolutionTransition() : 0;
       if (fallbackProvider) {
         this.resolvedProviderOverride = fallbackProvider;
       }
-      await this.configStore.writePartial(patch);
-      this.applyConfigStorePatchAfterWrite(patch);
-      return fallbackProvider ?? activeProvider;
+      try {
+        await this.configStore.writePartial(patch);
+        if (fallbackProvider && !this.isCurrentProviderResolutionTransition(transitionVersion)) {
+          return fallbackProvider;
+        }
+        this.applyConfigStorePatchAfterWrite(patch);
+        return fallbackProvider ?? activeProvider;
+      } catch (error) {
+        if (fallbackProvider && this.isCurrentProviderResolutionTransition(transitionVersion)) {
+          this.rollbackResolvedProviderOverride(activeProvider);
+        }
+        throw error;
+      }
     }
 
     this.setProviderEnabled(provider, enabled);
@@ -598,7 +661,11 @@ export class ProviderManager {
 
     if (this.configStore) {
       const patch = this.buildProviderSwitchPatch(provider);
+      const transitionVersion = this.beginProviderResolutionTransition();
       await this.configStore.writePartial(patch);
+      if (!this.isCurrentProviderResolutionTransition(transitionVersion)) {
+        return provider;
+      }
       this.applyConfigStorePatchAfterWrite(patch);
       return provider;
     }

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -467,7 +467,7 @@ export class ProviderManager {
     if (fallbackProvider) {
       logger.info({ module: 'provider', msg: 'Falling back to available provider', from: configured, to: fallbackProvider });
       this.persistActiveProvider(fallbackProvider);
-      return fallbackProvider;
+      return this.configStore ? this.getActiveProviderId() : fallbackProvider;
     }
 
     // No provider found — keep the configured one and let downstream handle the error

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -330,12 +330,10 @@ export class ProviderManager {
     return this.configStore ? this.configStore.current as FlightdeckConfig : null;
   }
 
-  private clearResolvedProviderOverrideIfAligned(providerId?: ProviderId): void {
+  private clearResolvedProviderOverride(providerId?: ProviderId): void {
     if (!this.configStore || !this.resolvedProviderOverride) return;
-    if (providerId && this.resolvedProviderOverride !== providerId) return;
-    if (this.configStore.current.provider.id === this.resolvedProviderOverride) {
-      this.resolvedProviderOverride = null;
-    }
+    if (providerId && this.configStore.current.provider.id !== providerId) return;
+    this.resolvedProviderOverride = null;
   }
 
   private buildProviderSwitchPatch(provider: ProviderId): { provider: Partial<FlightdeckConfig['provider']> } {
@@ -361,7 +359,7 @@ export class ProviderManager {
     if (patch.provider) {
       config.provider = { ...config.provider, ...patch.provider };
       if (patch.provider.id) {
-        this.clearResolvedProviderOverrideIfAligned(patch.provider.id as ProviderId);
+        this.clearResolvedProviderOverride(patch.provider.id as ProviderId);
       }
     }
     if (patch.providerSettings) {

--- a/packages/server/src/providers/ProviderManager.ts
+++ b/packages/server/src/providers/ProviderManager.ts
@@ -14,6 +14,7 @@
 
 import { execSync } from 'node:child_process';
 import { execFile as execFileCb } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { promisify } from 'node:util';
 import type { Database } from '../db/database.js';
 import type { ConfigStore } from '../config/ConfigStore.js';
@@ -89,7 +90,7 @@ const ASYNC_EXEC_TIMEOUT_MS = 5_000;
 
 // ── ProviderManager ──────────────────────────────────────────────
 
-export class ProviderManager {
+export class ProviderManager extends EventEmitter {
   private readonly db: Database | undefined;
   private readonly configStore: ConfigStore | undefined;
   private readonly exec: (cmd: string) => string;
@@ -114,6 +115,7 @@ export class ProviderManager {
     execCommandAsync?: (cmd: string, args: string[]) => Promise<string>;
     cacheTtlMs?: number;
   } = {}) {
+    super();
     this.db = opts.db;
     this.configStore = opts.configStore;
     this.exec = opts.execCommand ?? ((cmd) => execSync(cmd, { encoding: 'utf8', timeout: 5_000 }).trim());
@@ -343,6 +345,7 @@ export class ProviderManager {
     this.providerResolutionVersion += 1;
     this.resolvedProviderOverride = null;
     this.failedProviderPersistenceConfiguredId = null;
+    this.emit('provider:runtime-changed');
   }
 
   private beginProviderResolutionTransition(): number {
@@ -535,6 +538,7 @@ export class ProviderManager {
       logger.info({ module: 'provider', msg: 'Falling back to available provider', from: configured, to: fallbackProvider });
       const transitionVersion = this.beginProviderResolutionTransition();
       this.resolvedProviderOverride = fallbackProvider;
+      this.emit('provider:runtime-changed');
       this.persistActiveProvider(fallbackProvider, configured, transitionVersion);
       return fallbackProvider;
     }
@@ -629,6 +633,7 @@ export class ProviderManager {
       const transitionVersion = fallbackProvider ? this.beginProviderResolutionTransition() : 0;
       if (fallbackProvider) {
         this.resolvedProviderOverride = fallbackProvider;
+        this.emit('provider:runtime-changed');
       }
       try {
         await this.configStore.writePartial(patch);

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -576,9 +576,18 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
       // copilot is installed but explicitly disabled — should fall back to claude
       const result = mgr.resolveAndPersistProvider();
-      expect(result).toBe('copilot');
+      expect(result).toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('claude');
       expect(configStore.writePartial).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: expect.objectContaining({ id: 'claude' }) }),
+        expect.objectContaining({
+          provider: {
+            id: 'claude',
+            binaryOverride: undefined,
+            argsOverride: undefined,
+            envOverride: undefined,
+            cloudProvider: undefined,
+          },
+        }),
       );
     });
 
@@ -594,14 +603,23 @@ describe('ProviderManager', () => {
 
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
       const result = mgr.resolveAndPersistProvider();
-      expect(result).toBe('copilot');
+      expect(result).toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('claude');
       // Should persist the fallback
       expect(configStore.writePartial).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: expect.objectContaining({ id: 'claude' }) }),
+        expect.objectContaining({
+          provider: {
+            id: 'claude',
+            binaryOverride: undefined,
+            argsOverride: undefined,
+            envOverride: undefined,
+            cloudProvider: undefined,
+          },
+        }),
       );
     });
 
-    it('keeps resolveAndPersistProvider aligned with current active provider until fallback persistence completes', async () => {
+    it('switches reads to the fallback immediately while fallback persistence is pending', async () => {
       let resolveWrite: (() => void) | undefined;
       const configStore = createMockConfigStore({
         providerId: 'copilot',
@@ -611,6 +629,9 @@ describe('ProviderManager', () => {
         },
         providerRanking: ['copilot', 'claude', 'gemini'],
       });
+      configStore.current.provider.binaryOverride = '/custom/copilot';
+      configStore.current.provider.argsOverride = ['--copilot-only'];
+      configStore.current.provider.envOverride = { COPILOT_ONLY: '1' };
       configStore.writePartial = vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
         resolveWrite = resolve;
       }));
@@ -622,14 +643,21 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
 
       expect(mgr.getActiveProviderId()).toBe('copilot');
-      expect(mgr.resolveAndPersistProvider()).toBe('copilot');
-      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(mgr.resolveAndPersistProvider()).toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('claude');
 
       resolveWrite?.();
       await Promise.resolve();
 
       expect(mgr.getActiveProviderId()).toBe('claude');
       expect(mgr.resolveAndPersistProvider()).toBe('claude');
+      expect(configStore.current.provider).toEqual({
+        id: 'claude',
+        binaryOverride: undefined,
+        argsOverride: undefined,
+        envOverride: undefined,
+        cloudProvider: undefined,
+      });
     });
 
     it('updates config-store reads after a successful persisted provider write', async () => {
@@ -655,11 +683,17 @@ describe('ProviderManager', () => {
       expect(configStore.current.providerSettings.copilot.enabled).toBe(false);
       expect(configStore.writePartial).toHaveBeenCalledWith({
         providerSettings: { copilot: { enabled: false, models: [] } },
-        provider: { id: 'claude' },
+        provider: {
+          id: 'claude',
+          binaryOverride: undefined,
+          argsOverride: undefined,
+          envOverride: undefined,
+          cloudProvider: undefined,
+        },
       });
     });
 
-    it('does not mutate config-store reads before a provider write succeeds', async () => {
+    it('switches runtime reads immediately while a persisted provider write is pending', async () => {
       let resolveWrite: (() => void) | undefined;
       const configStore = createMockConfigStore({
         providerId: 'copilot',
@@ -681,7 +715,7 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
       const writePromise = mgr.setProviderEnabledPersisted('copilot', false);
 
-      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(mgr.getActiveProviderId()).toBe('claude');
       expect(configStore.current.provider.id).toBe('copilot');
       expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
 
@@ -711,7 +745,7 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
 
       await expect(mgr.setProviderEnabledPersisted('copilot', false)).rejects.toThrow('write failed');
-      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(mgr.getActiveProviderId()).toBe('claude');
       expect(configStore.current.provider.id).toBe('copilot');
       expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
     });

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -597,6 +597,33 @@ describe('ProviderManager', () => {
         expect.objectContaining({ provider: expect.objectContaining({ id: 'claude' }) }),
       );
     });
+
+    it('updates config-store reads immediately when disabling the active provider', () => {
+      const configStore = createMockConfigStore({
+        providerId: 'copilot',
+        providerSettings: {
+          copilot: { enabled: true, models: [] },
+          claude: { enabled: true, models: [] },
+        },
+        providerRanking: ['copilot', 'claude', 'gemini'],
+      });
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+      mgr.setProviderEnabled('copilot', false);
+
+      expect(mgr.getActiveProviderId()).toBe('claude');
+      expect(configStore.current.provider.id).toBe('claude');
+      expect(configStore.current.providerSettings.copilot.enabled).toBe(false);
+      expect(configStore.writePartial).toHaveBeenCalledWith({
+        providerSettings: { copilot: { enabled: false, models: [] } },
+        provider: { id: 'claude' },
+      });
+    });
   });
 
   // ── getActiveProviderId fallback ────────────────────────

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -370,6 +370,35 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ execCommand: exec as any });
       expect(mgr.isProviderEnabled('claude')).toBe(true);
     });
+
+    it('falls back to another usable provider when disabling the active provider', () => {
+      const mgr = createManager();
+      mgr.setActiveProviderId('copilot');
+      mgr.setProviderRanking(['copilot', 'claude', 'gemini', 'codex', 'cursor', 'opencode']);
+
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      mgr.setProviderEnabled('copilot', false);
+      expect(mgr.getActiveProviderId()).toBe('claude');
+    });
+
+    it('rejects disabling the active provider when no fallback is available', () => {
+      const mgr = createManager();
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        throw new Error('not found');
+      });
+      mgr.setActiveProviderId('copilot');
+
+      expect(() => mgr.setProviderEnabled('copilot', false)).toThrow(
+        "Cannot disable active provider 'copilot' without another installed and enabled provider",
+      );
+      expect(mgr.isProviderEnabled('copilot')).toBe(true);
+    });
   });
 
   // ── model preferences ────────────────────────────────────
@@ -445,6 +474,7 @@ describe('ProviderManager', () => {
       const mgr = createManager();
       mgr.setActiveProviderId('copilot');
       mgr.setProviderEnabled('copilot', true);
+      mgr.setProviderRanking(['copilot', 'claude', 'gemini', 'codex', 'cursor', 'opencode']);
 
       // Mock: copilot is installed but disabled
       exec.mockImplementation((cmd: string) => {
@@ -455,7 +485,6 @@ describe('ProviderManager', () => {
       // Disable copilot, enable claude
       mgr.setProviderEnabled('copilot', false);
       mgr.setProviderEnabled('claude', true);
-      mgr.setProviderRanking(['copilot', 'claude', 'gemini', 'codex', 'cursor', 'opencode']);
 
       const result = mgr.resolveAndPersistProvider();
       expect(result).toBe('claude');
@@ -571,6 +600,31 @@ describe('ProviderManager', () => {
   });
 
   // ── getActiveProviderId fallback ────────────────────────
+
+  describe('setActiveProviderId', () => {
+    it('persists a usable provider', () => {
+      const mgr = createManager();
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      mgr.setActiveProviderId('claude');
+      expect(mgr.getActiveProviderId()).toBe('claude');
+    });
+
+    it('rejects disabled providers', () => {
+      const mgr = createManager();
+      mgr.setProviderEnabled('claude', false);
+      expect(() => mgr.setActiveProviderId('claude')).toThrow("Provider 'claude' is disabled");
+    });
+
+    it('rejects uninstalled providers', () => {
+      const mgr = createManager();
+      exec.mockImplementation(() => { throw new Error('not found'); });
+      expect(() => mgr.setActiveProviderId('gemini')).toThrow("Provider 'gemini' is not installed");
+    });
+  });
 
   describe('getActiveProviderId without db or configStore', () => {
     it('returns first installed provider instead of hardcoded copilot', () => {

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -747,12 +747,15 @@ describe('ProviderManager', () => {
       });
 
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+      const runtimeChanged = vi.fn();
+      mgr.on('provider:runtime-changed', runtimeChanged);
 
       await expect(mgr.setProviderEnabledPersisted('copilot', false)).rejects.toThrow('write failed');
       expect(mgr.getActiveProviderId()).toBe('copilot');
       expect(mgr.resolveAndPersistProvider()).toBe('copilot');
       expect(configStore.current.provider.id).toBe('copilot');
       expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
+      expect(runtimeChanged).toHaveBeenCalledTimes(2);
     });
 
     it('clears a stale fallback override after a later successful provider change', async () => {

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -749,6 +749,38 @@ describe('ProviderManager', () => {
       expect(configStore.current.provider.id).toBe('copilot');
       expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
     });
+
+    it('clears a stale fallback override after a later successful provider change', async () => {
+      const configStore = createMockConfigStore({
+        providerId: 'copilot',
+        providerSettings: {
+          copilot: { enabled: true, models: [] },
+          claude: { enabled: true, models: [] },
+          gemini: { enabled: true, models: [] },
+        },
+        providerRanking: ['copilot', 'claude', 'gemini'],
+      });
+      configStore.writePartial = vi.fn()
+        .mockRejectedValueOnce(new Error('write failed'))
+        .mockResolvedValueOnce(undefined);
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} gemini`) return '/usr/local/bin/gemini';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+
+      await expect(mgr.setProviderEnabledPersisted('copilot', false)).rejects.toThrow('write failed');
+      expect(mgr.getActiveProviderId()).toBe('claude');
+      expect(configStore.current.provider.id).toBe('copilot');
+
+      await expect(mgr.setActiveProviderIdPersisted('gemini')).resolves.toBe('gemini');
+
+      expect(mgr.getActiveProviderId()).toBe('gemini');
+      expect(configStore.current.provider.id).toBe('gemini');
+    });
   });
 
   // ── getActiveProviderId fallback ────────────────────────

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -576,7 +576,10 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
       // copilot is installed but explicitly disabled — should fall back to claude
       const result = mgr.resolveAndPersistProvider();
-      expect(result).toBe('claude');
+      expect(result).toBe('copilot');
+      expect(configStore.writePartial).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: expect.objectContaining({ id: 'claude' }) }),
+      );
     });
 
     it('falls back through ranking when configured provider not installed', () => {
@@ -591,11 +594,42 @@ describe('ProviderManager', () => {
 
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
       const result = mgr.resolveAndPersistProvider();
-      expect(result).toBe('claude');
+      expect(result).toBe('copilot');
       // Should persist the fallback
       expect(configStore.writePartial).toHaveBeenCalledWith(
         expect.objectContaining({ provider: expect.objectContaining({ id: 'claude' }) }),
       );
+    });
+
+    it('keeps resolveAndPersistProvider aligned with current active provider until fallback persistence completes', async () => {
+      let resolveWrite: (() => void) | undefined;
+      const configStore = createMockConfigStore({
+        providerId: 'copilot',
+        providerSettings: {
+          copilot: { enabled: true, models: [] },
+          claude: { enabled: true, models: [] },
+        },
+        providerRanking: ['copilot', 'claude', 'gemini'],
+      });
+      configStore.writePartial = vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      }));
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+
+      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(mgr.resolveAndPersistProvider()).toBe('copilot');
+      expect(mgr.getActiveProviderId()).toBe('copilot');
+
+      resolveWrite?.();
+      await Promise.resolve();
+
+      expect(mgr.getActiveProviderId()).toBe('claude');
+      expect(mgr.resolveAndPersistProvider()).toBe('claude');
     });
 
     it('updates config-store reads after a successful persisted provider write', async () => {

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -598,7 +598,7 @@ describe('ProviderManager', () => {
       );
     });
 
-    it('updates config-store reads immediately when disabling the active provider', () => {
+    it('updates config-store reads after a successful persisted provider write', async () => {
       const configStore = createMockConfigStore({
         providerId: 'copilot',
         providerSettings: {
@@ -614,7 +614,7 @@ describe('ProviderManager', () => {
       });
 
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
-      mgr.setProviderEnabled('copilot', false);
+      await expect(mgr.setProviderEnabledPersisted('copilot', false)).resolves.toBe('claude');
 
       expect(mgr.getActiveProviderId()).toBe('claude');
       expect(configStore.current.provider.id).toBe('claude');
@@ -623,6 +623,63 @@ describe('ProviderManager', () => {
         providerSettings: { copilot: { enabled: false, models: [] } },
         provider: { id: 'claude' },
       });
+    });
+
+    it('does not mutate config-store reads before a provider write succeeds', async () => {
+      let resolveWrite: (() => void) | undefined;
+      const configStore = createMockConfigStore({
+        providerId: 'copilot',
+        providerSettings: {
+          copilot: { enabled: true, models: [] },
+          claude: { enabled: true, models: [] },
+        },
+        providerRanking: ['copilot', 'claude', 'gemini'],
+      });
+      configStore.writePartial = vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      }));
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+      const writePromise = mgr.setProviderEnabledPersisted('copilot', false);
+
+      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(configStore.current.provider.id).toBe('copilot');
+      expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
+
+      resolveWrite?.();
+      await expect(writePromise).resolves.toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('claude');
+      expect(configStore.current.provider.id).toBe('claude');
+      expect(configStore.current.providerSettings.copilot.enabled).toBe(false);
+    });
+
+    it('keeps config-store reads aligned with persisted state when provider write fails', async () => {
+      const configStore = createMockConfigStore({
+        providerId: 'copilot',
+        providerSettings: {
+          copilot: { enabled: true, models: [] },
+          claude: { enabled: true, models: [] },
+        },
+        providerRanking: ['copilot', 'claude', 'gemini'],
+      });
+      configStore.writePartial = vi.fn().mockRejectedValue(new Error('write failed'));
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+
+      await expect(mgr.setProviderEnabledPersisted('copilot', false)).rejects.toThrow('write failed');
+      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(configStore.current.provider.id).toBe('copilot');
+      expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
     });
   });
 

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ProviderManager } from '../ProviderManager.js';
 import { WHICH_COMMAND } from '../../utils/platform.js';
@@ -526,6 +527,7 @@ describe('ProviderManager', () => {
       providerSettings?: Record<string, { enabled: boolean; models: string[] }>;
       providerRanking?: string[];
     }) {
+      const emitter = new EventEmitter();
       const config = {
         provider: { id: overrides?.providerId ?? 'copilot' },
         providerSettings: overrides?.providerSettings ?? {},
@@ -534,6 +536,8 @@ describe('ProviderManager', () => {
       return {
         current: config,
         writePartial: vi.fn().mockResolvedValue(undefined),
+        on: emitter.on.bind(emitter),
+        emit: emitter.emit.bind(emitter),
       };
     }
 
@@ -726,7 +730,7 @@ describe('ProviderManager', () => {
       expect(configStore.current.providerSettings.copilot.enabled).toBe(false);
     });
 
-    it('keeps config-store reads aligned with persisted state when provider write fails', async () => {
+    it('rolls back runtime override state when provider write fails', async () => {
       const configStore = createMockConfigStore({
         providerId: 'copilot',
         providerSettings: {
@@ -745,7 +749,8 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
 
       await expect(mgr.setProviderEnabledPersisted('copilot', false)).rejects.toThrow('write failed');
-      expect(mgr.getActiveProviderId()).toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('copilot');
+      expect(mgr.resolveAndPersistProvider()).toBe('copilot');
       expect(configStore.current.provider.id).toBe('copilot');
       expect(configStore.current.providerSettings.copilot.enabled).toBe(true);
     });
@@ -773,13 +778,52 @@ describe('ProviderManager', () => {
       const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
 
       await expect(mgr.setProviderEnabledPersisted('copilot', false)).rejects.toThrow('write failed');
-      expect(mgr.getActiveProviderId()).toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('copilot');
       expect(configStore.current.provider.id).toBe('copilot');
+      expect(mgr.resolveAndPersistProvider()).toBe('copilot');
 
       await expect(mgr.setActiveProviderIdPersisted('gemini')).resolves.toBe('gemini');
 
       expect(mgr.getActiveProviderId()).toBe('gemini');
       expect(configStore.current.provider.id).toBe('gemini');
+    });
+
+    it('clears stale runtime override state on external config reloads', async () => {
+      let resolveWrite: (() => void) | undefined;
+      const configStore = createMockConfigStore({
+        providerId: 'copilot',
+        providerSettings: {
+          copilot: { enabled: true, models: [] },
+          claude: { enabled: true, models: [] },
+          gemini: { enabled: true, models: [] },
+        },
+        providerRanking: ['copilot', 'claude', 'gemini'],
+      });
+      configStore.writePartial = vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      }));
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        if (cmd === `${WHICH_COMMAND} gemini`) return '/usr/local/bin/gemini';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+
+      expect(mgr.resolveAndPersistProvider()).toBe('claude');
+      expect(mgr.getActiveProviderId()).toBe('claude');
+
+      configStore.current.provider.id = 'gemini';
+      configStore.emit('config:provider:changed', { config: configStore.current.provider, diffs: [] });
+      configStore.emit('config:reloaded', { config: configStore.current, diffs: [], previous: configStore.current });
+
+      expect(mgr.getActiveProviderId()).toBe('gemini');
+      expect(mgr.resolveAndPersistProvider()).toBe('gemini');
+
+      resolveWrite?.();
+      await Promise.resolve();
+
+      expect(mgr.getActiveProviderId()).toBe('gemini');
     });
   });
 

--- a/packages/server/src/providers/__tests__/ProviderManager.test.ts
+++ b/packages/server/src/providers/__tests__/ProviderManager.test.ts
@@ -372,6 +372,57 @@ describe('ProviderManager', () => {
       expect(mgr.isProviderEnabled('claude')).toBe(true);
     });
 
+    it('clears provider overrides when config-store fallback disables the active provider', async () => {
+      const emitter = new EventEmitter();
+      const configStore = {
+        current: {
+          provider: {
+            id: 'copilot',
+            binaryOverride: '/custom/copilot',
+            argsOverride: ['--copilot-only'],
+            envOverride: { COPILOT_ONLY: '1' },
+          },
+          providerSettings: {
+            copilot: { enabled: true, models: [] },
+            claude: { enabled: true, models: [] },
+          },
+          providerRanking: ['copilot', 'claude'],
+        },
+        writePartial: vi.fn().mockResolvedValue(undefined),
+        on: emitter.on.bind(emitter),
+        emit: emitter.emit.bind(emitter),
+      };
+
+      exec.mockImplementation((cmd: string) => {
+        if (cmd === `${WHICH_COMMAND} copilot`) return '/usr/local/bin/copilot';
+        if (cmd === `${WHICH_COMMAND} claude-agent-acp`) return '/usr/local/bin/claude-agent-acp';
+        throw new Error('not found');
+      });
+
+      const mgr = new ProviderManager({ configStore: configStore as any, execCommand: exec as any });
+
+      mgr.setProviderEnabled('copilot', false);
+      await Promise.resolve();
+
+      expect(configStore.writePartial).toHaveBeenCalledWith({
+        providerSettings: { copilot: { enabled: false, models: [] } },
+        provider: {
+          id: 'claude',
+          binaryOverride: undefined,
+          argsOverride: undefined,
+          envOverride: undefined,
+          cloudProvider: undefined,
+        },
+      });
+      expect(configStore.current.provider).toEqual({
+        id: 'claude',
+        binaryOverride: undefined,
+        argsOverride: undefined,
+        envOverride: undefined,
+        cloudProvider: undefined,
+      });
+    });
+
     it('falls back to another usable provider when disabling the active provider', () => {
       const mgr = createManager();
       mgr.setActiveProviderId('copilot');

--- a/packages/server/src/routes/settings.test.ts
+++ b/packages/server/src/routes/settings.test.ts
@@ -314,7 +314,7 @@ describe('settings routes', () => {
     it('returns updated status in response', async () => {
       mockGetStatusAsync.mockResolvedValue({ ...MOCK_STATUSES[0], enabled: false });
       mockGetModelPrefs.mockReturnValue({ defaultModel: 'gpt-5' });
-      mockResolveAndPersistProvider.mockReturnValue('claude');
+      mockGetActiveProviderId.mockReturnValue('claude');
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -323,6 +323,24 @@ describe('settings routes', () => {
       const body = await res.json();
       expect(body.enabled).toBe(false);
       expect(body.modelPreferences).toEqual({ defaultModel: 'gpt-5' });
+      expect(body.activeProvider).toBe('claude');
+    });
+
+    it('returns the immediately updated active provider after disabling the current one', async () => {
+      mockSetEnabled.mockImplementation(() => {
+        mockGetActiveProviderId.mockReturnValue('claude');
+      });
+      mockResolveAndPersistProvider.mockReturnValue('copilot');
+      mockGetStatusAsync.mockResolvedValue({ ...MOCK_STATUSES[0], enabled: false });
+
+      const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
       expect(body.activeProvider).toBe('claude');
     });
 
@@ -362,6 +380,7 @@ describe('settings routes', () => {
 
   describe('PUT /settings/provider', () => {
     it('sets the active provider when it is usable', async () => {
+      mockGetActiveProviderId.mockReturnValue('claude');
       const res = await fetch(`${baseUrl}/settings/provider`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },

--- a/packages/server/src/routes/settings.test.ts
+++ b/packages/server/src/routes/settings.test.ts
@@ -27,6 +27,11 @@ const mockInvalidateCache = vi.fn();
 const mockGetModelPrefs = vi.fn();
 const mockSetModelPrefs = vi.fn();
 const mockSetEnabled = vi.fn();
+const mockResolveAndPersistProvider = vi.fn();
+const mockGetActiveProviderId = vi.fn();
+const mockSetActiveProviderId = vi.fn();
+const mockGetProviderRanking = vi.fn();
+const mockSetProviderRanking = vi.fn();
 
 vi.mock('../providers/ProviderManager.js', () => ({
   ProviderManager: class MockProviderManager {
@@ -40,10 +45,11 @@ vi.mock('../providers/ProviderManager.js', () => ({
     setModelPreferences(id: string, prefs: any) { return mockSetModelPrefs(id, prefs); }
     setProviderEnabled(id: string, enabled: boolean) { return mockSetEnabled(id, enabled); }
     isProviderEnabled() { return true; }
-    getActiveProviderId() { return 'copilot'; }
-    setActiveProviderId() {}
-    getProviderRanking() { return ['copilot', 'claude', 'gemini', 'opencode', 'cursor', 'codex']; }
-    setProviderRanking() {}
+    resolveAndPersistProvider() { return mockResolveAndPersistProvider(); }
+    getActiveProviderId() { return mockGetActiveProviderId(); }
+    setActiveProviderId(id: string) { return mockSetActiveProviderId(id); }
+    getProviderRanking() { return mockGetProviderRanking(); }
+    setProviderRanking(ranking: string[]) { return mockSetProviderRanking(ranking); }
   },
 }));
 
@@ -127,6 +133,12 @@ describe('settings routes', () => {
       MOCK_STATUSES.find((s) => s.id === id) ?? (() => { throw new Error('Unknown'); })(),
     );
     mockGetModelPrefs.mockReturnValue({});
+    mockResolveAndPersistProvider.mockReturnValue('copilot');
+    mockGetActiveProviderId.mockReturnValue('copilot');
+    mockSetActiveProviderId.mockImplementation(() => {});
+    mockGetProviderRanking.mockReturnValue(['copilot', 'claude', 'gemini', 'opencode', 'cursor', 'codex']);
+    mockSetProviderRanking.mockImplementation(() => {});
+    mockSetEnabled.mockImplementation(() => {});
     baseUrl = await srv.start();
   });
 
@@ -277,6 +289,7 @@ describe('settings routes', () => {
   describe('PUT /settings/providers/:provider', () => {
     it('updates enabled state', async () => {
       mockGetStatusAsync.mockResolvedValue(MOCK_STATUSES[0]);
+      mockResolveAndPersistProvider.mockReturnValue('claude');
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -301,6 +314,7 @@ describe('settings routes', () => {
     it('returns updated status in response', async () => {
       mockGetStatusAsync.mockResolvedValue({ ...MOCK_STATUSES[0], enabled: false });
       mockGetModelPrefs.mockReturnValue({ defaultModel: 'gpt-5' });
+      mockResolveAndPersistProvider.mockReturnValue('claude');
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -309,6 +323,7 @@ describe('settings routes', () => {
       const body = await res.json();
       expect(body.enabled).toBe(false);
       expect(body.modelPreferences).toEqual({ defaultModel: 'gpt-5' });
+      expect(body.activeProvider).toBe('claude');
     });
 
     it('returns 404 for unknown provider', async () => {
@@ -319,6 +334,83 @@ describe('settings routes', () => {
       });
       expect(res.status).toBe(404);
     });
+
+    it('returns 409 when disabling the active provider would leave no fallback', async () => {
+      mockSetEnabled.mockImplementation(() => { throw new Error('Cannot disable active provider'); });
+      const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toContain('Cannot disable active provider');
+    });
+  });
+
+  // ── GET/PUT /settings/provider ───────────────────────────
+
+  describe('GET /settings/provider', () => {
+    it('returns the resolved active provider', async () => {
+      mockResolveAndPersistProvider.mockReturnValue('claude');
+      const res = await fetch(`${baseUrl}/settings/provider`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ activeProvider: 'claude' });
+    });
+  });
+
+  describe('PUT /settings/provider', () => {
+    it('sets the active provider when it is usable', async () => {
+      const res = await fetch(`${baseUrl}/settings/provider`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'claude' }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ activeProvider: 'claude' });
+      expect(mockSetActiveProviderId).toHaveBeenCalledWith('claude');
+    });
+
+    it('returns 409 when the provider is unusable', async () => {
+      mockSetActiveProviderId.mockImplementation(() => {
+        throw new Error("Provider 'gemini' is not installed");
+      });
+      const res = await fetch(`${baseUrl}/settings/provider`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'gemini' }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toContain("Provider 'gemini' is not installed");
+    });
+  });
+
+  // ── GET/PUT /settings/provider-ranking ───────────────────
+
+  describe('GET /settings/provider-ranking', () => {
+    it('returns the provider ranking', async () => {
+      const res = await fetch(`${baseUrl}/settings/provider-ranking`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ranking).toEqual(['copilot', 'claude', 'gemini', 'opencode', 'cursor', 'codex']);
+    });
+  });
+
+  describe('PUT /settings/provider-ranking', () => {
+    it('persists a valid provider ranking', async () => {
+      mockGetProviderRanking.mockReturnValue(['claude', 'copilot']);
+      const res = await fetch(`${baseUrl}/settings/provider-ranking`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ranking: ['claude', 'copilot'] }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(mockSetProviderRanking).toHaveBeenCalledWith(['claude', 'copilot']);
+      expect(body.ranking).toEqual(['claude', 'copilot']);
+    });
   });
 });
-

--- a/packages/server/src/routes/settings.test.ts
+++ b/packages/server/src/routes/settings.test.ts
@@ -27,9 +27,11 @@ const mockInvalidateCache = vi.fn();
 const mockGetModelPrefs = vi.fn();
 const mockSetModelPrefs = vi.fn();
 const mockSetEnabled = vi.fn();
+const mockSetEnabledPersisted = vi.fn();
 const mockResolveAndPersistProvider = vi.fn();
 const mockGetActiveProviderId = vi.fn();
 const mockSetActiveProviderId = vi.fn();
+const mockSetActiveProviderIdPersisted = vi.fn();
 const mockGetProviderRanking = vi.fn();
 const mockSetProviderRanking = vi.fn();
 
@@ -44,10 +46,12 @@ vi.mock('../providers/ProviderManager.js', () => ({
     getModelPreferences(id: string) { return mockGetModelPrefs(id); }
     setModelPreferences(id: string, prefs: any) { return mockSetModelPrefs(id, prefs); }
     setProviderEnabled(id: string, enabled: boolean) { return mockSetEnabled(id, enabled); }
+    setProviderEnabledPersisted(id: string, enabled: boolean) { return mockSetEnabledPersisted(id, enabled); }
     isProviderEnabled() { return true; }
     resolveAndPersistProvider() { return mockResolveAndPersistProvider(); }
     getActiveProviderId() { return mockGetActiveProviderId(); }
     setActiveProviderId(id: string) { return mockSetActiveProviderId(id); }
+    setActiveProviderIdPersisted(id: string) { return mockSetActiveProviderIdPersisted(id); }
     getProviderRanking() { return mockGetProviderRanking(); }
     setProviderRanking(ranking: string[]) { return mockSetProviderRanking(ranking); }
   },
@@ -136,9 +140,11 @@ describe('settings routes', () => {
     mockResolveAndPersistProvider.mockReturnValue('copilot');
     mockGetActiveProviderId.mockReturnValue('copilot');
     mockSetActiveProviderId.mockImplementation(() => {});
+    mockSetActiveProviderIdPersisted.mockResolvedValue('copilot');
     mockGetProviderRanking.mockReturnValue(['copilot', 'claude', 'gemini', 'opencode', 'cursor', 'codex']);
     mockSetProviderRanking.mockImplementation(() => {});
     mockSetEnabled.mockImplementation(() => {});
+    mockSetEnabledPersisted.mockResolvedValue('copilot');
     baseUrl = await srv.start();
   });
 
@@ -289,14 +295,14 @@ describe('settings routes', () => {
   describe('PUT /settings/providers/:provider', () => {
     it('updates enabled state', async () => {
       mockGetStatusAsync.mockResolvedValue(MOCK_STATUSES[0]);
-      mockResolveAndPersistProvider.mockReturnValue('claude');
+      mockSetEnabledPersisted.mockResolvedValue('claude');
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled: false }),
       });
       expect(res.status).toBe(200);
-      expect(mockSetEnabled).toHaveBeenCalledWith('copilot', false);
+      expect(mockSetEnabledPersisted).toHaveBeenCalledWith('copilot', false);
     });
 
     it('updates model preferences', async () => {
@@ -314,7 +320,7 @@ describe('settings routes', () => {
     it('returns updated status in response', async () => {
       mockGetStatusAsync.mockResolvedValue({ ...MOCK_STATUSES[0], enabled: false });
       mockGetModelPrefs.mockReturnValue({ defaultModel: 'gpt-5' });
-      mockGetActiveProviderId.mockReturnValue('claude');
+      mockSetEnabledPersisted.mockResolvedValue('claude');
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -327,10 +333,7 @@ describe('settings routes', () => {
     });
 
     it('returns the immediately updated active provider after disabling the current one', async () => {
-      mockSetEnabled.mockImplementation(() => {
-        mockGetActiveProviderId.mockReturnValue('claude');
-      });
-      mockResolveAndPersistProvider.mockReturnValue('copilot');
+      mockSetEnabledPersisted.mockResolvedValue('claude');
       mockGetStatusAsync.mockResolvedValue({ ...MOCK_STATUSES[0], enabled: false });
 
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
@@ -354,7 +357,7 @@ describe('settings routes', () => {
     });
 
     it('returns 409 when disabling the active provider would leave no fallback', async () => {
-      mockSetEnabled.mockImplementation(() => { throw new Error('Cannot disable active provider'); });
+      mockSetEnabledPersisted.mockRejectedValue(new Error('Cannot disable active provider'));
       const res = await fetch(`${baseUrl}/settings/providers/copilot`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -380,7 +383,7 @@ describe('settings routes', () => {
 
   describe('PUT /settings/provider', () => {
     it('sets the active provider when it is usable', async () => {
-      mockGetActiveProviderId.mockReturnValue('claude');
+      mockSetActiveProviderIdPersisted.mockResolvedValue('claude');
       const res = await fetch(`${baseUrl}/settings/provider`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -389,13 +392,11 @@ describe('settings routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual({ activeProvider: 'claude' });
-      expect(mockSetActiveProviderId).toHaveBeenCalledWith('claude');
+      expect(mockSetActiveProviderIdPersisted).toHaveBeenCalledWith('claude');
     });
 
     it('returns 409 when the provider is unusable', async () => {
-      mockSetActiveProviderId.mockImplementation(() => {
-        throw new Error("Provider 'gemini' is not installed");
-      });
+      mockSetActiveProviderIdPersisted.mockRejectedValue(new Error("Provider 'gemini' is not installed"));
       const res = await fetch(`${baseUrl}/settings/provider`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -404,6 +405,20 @@ describe('settings routes', () => {
       expect(res.status).toBe(409);
       const body = await res.json();
       expect(body.error).toContain("Provider 'gemini' is not installed");
+    });
+
+    it('does not report a new active provider when persistence fails', async () => {
+      mockSetActiveProviderIdPersisted.mockRejectedValue(new Error('write failed'));
+      mockGetActiveProviderId.mockReturnValue('copilot');
+      const res = await fetch(`${baseUrl}/settings/provider`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'claude' }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toContain('write failed');
+      expect(mockGetActiveProviderId).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -109,7 +109,7 @@ export function settingsRoutes(ctx: AppContext): Router {
     if (enabled !== undefined) {
       try {
         pm.setProviderEnabled(provider, enabled);
-        activeProvider = pm.resolveAndPersistProvider();
+        activeProvider = pm.getActiveProviderId();
       } catch (err: any) {
         return res.status(409).json({ error: err.message || 'Failed to update provider enabled state' });
       }
@@ -144,7 +144,7 @@ export function settingsRoutes(ctx: AppContext): Router {
     }
     try {
       pm.setActiveProviderId(id as ProviderId);
-      res.json({ activeProvider: id });
+      res.json({ activeProvider: pm.getActiveProviderId() });
     } catch (err: any) {
       res.status(409).json({ error: err.message || 'Failed to set active provider' });
     }

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -105,8 +105,14 @@ export function settingsRoutes(ctx: AppContext): Router {
       modelPreferences?: { defaultModel?: string; preferredModels?: string[] };
     };
 
+    let activeProvider = pm.getActiveProviderId();
     if (enabled !== undefined) {
-      pm.setProviderEnabled(provider, enabled);
+      try {
+        pm.setProviderEnabled(provider, enabled);
+        activeProvider = pm.resolveAndPersistProvider();
+      } catch (err: any) {
+        return res.status(409).json({ error: err.message || 'Failed to update provider enabled state' });
+      }
     }
     if (modelPreferences) {
       pm.setModelPreferences(provider, modelPreferences);
@@ -115,7 +121,7 @@ export function settingsRoutes(ctx: AppContext): Router {
     try {
       const status = await pm.getProviderStatusAsync(provider);
       const prefs = pm.getModelPreferences(provider);
-      res.json({ ...status, modelPreferences: prefs });
+      res.json({ ...status, modelPreferences: prefs, activeProvider });
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Failed to get provider status' });
     }
@@ -125,7 +131,7 @@ export function settingsRoutes(ctx: AppContext): Router {
    * GET /settings/provider — get the active provider ID.
    */
   router.get('/settings/provider', (_req, res) => {
-    res.json({ activeProvider: pm.getActiveProviderId() });
+    res.json({ activeProvider: pm.resolveAndPersistProvider() });
   });
 
   /**
@@ -136,8 +142,12 @@ export function settingsRoutes(ctx: AppContext): Router {
     if (!id || !isValidProviderId(id)) {
       return res.status(400).json({ error: `Invalid provider: ${id}` });
     }
-    pm.setActiveProviderId(id as ProviderId);
-    res.json({ activeProvider: id });
+    try {
+      pm.setActiveProviderId(id as ProviderId);
+      res.json({ activeProvider: id });
+    } catch (err: any) {
+      res.status(409).json({ error: err.message || 'Failed to set active provider' });
+    }
   });
 
   /**
@@ -165,4 +175,3 @@ export function settingsRoutes(ctx: AppContext): Router {
 
   return router;
 }
-

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -122,6 +122,13 @@ export function settingsRoutes(ctx: AppContext): Router {
   });
 
   /**
+   * GET /settings/provider — get the active provider ID.
+   */
+  router.get('/settings/provider', (_req, res) => {
+    res.json({ activeProvider: pm.getActiveProviderId() });
+  });
+
+  /**
    * PUT /settings/provider — set the active provider.
    */
   router.put('/settings/provider', (req, res) => {

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -108,8 +108,7 @@ export function settingsRoutes(ctx: AppContext): Router {
     let activeProvider = pm.getActiveProviderId();
     if (enabled !== undefined) {
       try {
-        pm.setProviderEnabled(provider, enabled);
-        activeProvider = pm.getActiveProviderId();
+        activeProvider = await pm.setProviderEnabledPersisted(provider, enabled);
       } catch (err: any) {
         return res.status(409).json({ error: err.message || 'Failed to update provider enabled state' });
       }
@@ -137,14 +136,14 @@ export function settingsRoutes(ctx: AppContext): Router {
   /**
    * PUT /settings/provider — set the active provider.
    */
-  router.put('/settings/provider', (req, res) => {
+  router.put('/settings/provider', async (req, res) => {
     const { id } = req.body as { id?: string };
     if (!id || !isValidProviderId(id)) {
       return res.status(400).json({ error: `Invalid provider: ${id}` });
     }
     try {
-      pm.setActiveProviderId(id as ProviderId);
-      res.json({ activeProvider: pm.getActiveProviderId() });
+      const activeProvider = await pm.setActiveProviderIdPersisted(id as ProviderId);
+      res.json({ activeProvider });
     } catch (err: any) {
       res.status(409).json({ error: err.message || 'Failed to set active provider' });
     }

--- a/packages/web/src/components/Settings/ProvidersSection.tsx
+++ b/packages/web/src/components/Settings/ProvidersSection.tsx
@@ -489,7 +489,7 @@ export function ProvidersSection() {
                     }
                   : provider;
               });
-              nextActiveProviderId = findUsableProviderId(nextProviders, activeProviderIdRef.current);
+              nextActiveProviderId = findUsableProviderId(nextProviders, ranking, activeProviderIdRef.current);
               return nextProviders;
             });
 
@@ -518,6 +518,15 @@ export function ProvidersSection() {
       mounted = false;
     };
   }, [syncActiveProvider]);
+
+  useEffect(() => {
+    if (statusLoading) return;
+
+    const nextActiveProviderId = findUsableProviderId(providers, ranking, activeProviderIdRef.current);
+    if (nextActiveProviderId !== activeProviderIdRef.current) {
+      syncActiveProvider(nextActiveProviderId);
+    }
+  }, [providers, ranking, statusLoading, syncActiveProvider]);
 
   // Sort providers by ranking
   const sortedProviders = [...providers].sort((a, b) => {

--- a/packages/web/src/components/Settings/ProvidersSection.tsx
+++ b/packages/web/src/components/Settings/ProvidersSection.tsx
@@ -9,7 +9,7 @@
  * authentication guidance, and default CLI arguments.
  * Drag-and-drop reordering via @dnd-kit/sortable.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Cpu, Loader2, Zap, ExternalLink, ChevronDown, ChevronRight, Terminal, Settings2, GripVertical, LogIn, Check, X, Minus } from 'lucide-react';
 import { DndContext, closestCenter, PointerSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core';
 import type { DragEndEvent } from '@dnd-kit/core';
@@ -17,9 +17,11 @@ import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove, s
 import { CSS } from '@dnd-kit/utilities';
 import { getProvider, getAcpCapabilities } from '@flightdeck/shared';
 import { apiFetch } from '../../hooks/useApi';
+import { updateCachedActiveProvider } from '../../hooks/useModels';
 import { StatusBadge, providerStatusProps } from '../ui/StatusBadge';
 import { ProviderIcon } from '../ui/ProviderIcon';
 import { EmptyState } from '../ui/EmptyState';
+import { findUsableProviderId, normalizeProviderRanking } from '../providerPreferences';
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -55,6 +57,21 @@ interface ProviderStatus {
 interface TestResult {
   success: boolean;
   message: string;
+}
+
+interface ProviderUpdateResponse extends ProviderStatusData {
+  enabled: boolean;
+  activeProvider?: string;
+}
+
+function buildProviderStatuses(configs: ProviderConfig[]): ProviderStatus[] {
+  return configs.map((config) => ({
+    ...config,
+    installed: false,
+    authenticated: null,
+    binaryPath: null,
+    version: null,
+  }));
 }
 
 // ── Provider display metadata ───────────────────────────────────────
@@ -357,7 +374,7 @@ function ProviderCard({
           {/* Actions */}
           <div className="flex items-center gap-2 flex-wrap">
             {/* Set as active */}
-            {provider.installed && !isActive && (
+            {provider.installed && provider.enabled && !isActive && (
               <button
                 onClick={() => onSetActive(provider.id)}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-th-bg-hover text-th-text-alt hover:bg-th-bg-alt border border-th-border rounded-md transition-colors"
@@ -412,53 +429,95 @@ export function ProvidersSection() {
   const [configLoading, setConfigLoading] = useState(true);
   const [statusLoading, setStatusLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const activeProviderIdRef = useRef<string | null>(null);
 
-  // Phase 1: Load config + ranking + active provider instantly (no CLI calls)
+  const syncActiveProvider = useCallback((nextActiveProviderId: string | null) => {
+    activeProviderIdRef.current = nextActiveProviderId;
+    setActiveProviderId(nextActiveProviderId);
+    if (nextActiveProviderId) {
+      updateCachedActiveProvider(nextActiveProviderId);
+    }
+  }, []);
+
+  // Phase 1: load config instantly, then hydrate ranking/active provider without blocking the UI.
   useEffect(() => {
-    Promise.all([
-      apiFetch<ProviderConfig[]>('/settings/providers'),
-      apiFetch<{ ranking: string[] }>('/settings/provider-ranking'),
-      apiFetch<{ activeProvider: string }>('/settings/provider'),
-    ])
-      .then(([configs, { ranking: r }, { activeProvider }]) => {
-        setActiveProviderId(activeProvider);
-        // Build initial provider list from config (no status yet)
-        setProviders(configs.map((c) => ({
-          ...c,
-          installed: false,
-          authenticated: null,
-          binaryPath: null,
-          version: null,
-        })));
-        setRanking(r);
+    let mounted = true;
+
+    apiFetch<ProviderConfig[]>('/settings/providers')
+      .then((configs) => {
+        if (!mounted) return;
+
+        setProviders(buildProviderStatuses(configs));
+        setRanking(normalizeProviderRanking(configs));
         setConfigLoading(false);
 
-        // Phase 2: Load CLI detection statuses asynchronously
-        apiFetch<ProviderStatusData[]>('/settings/providers/status')
-          .then((statuses) => {
-            const statusMap = new Map(statuses.map((s) => [s.id, s]));
-            setProviders((prev) =>
-              prev.map((p) => {
-                const status = statusMap.get(p.id);
-                return status
-                  ? { ...p, installed: status.installed, authenticated: status.authenticated, binaryPath: status.binaryPath, version: status.version }
-                  : p;
-              }),
-            );
+        apiFetch<{ ranking: string[] }>('/settings/provider-ranking')
+          .then(({ ranking: nextRanking }) => {
+            if (!mounted) return;
+            setRanking(normalizeProviderRanking(configs, nextRanking));
           })
           .catch((err) => {
-            // Status fetch failure is non-critical — toggles still work
+            logger.warn('Failed to load provider ranking, using default order:', err);
+          });
+
+        apiFetch<{ activeProvider: string }>('/settings/provider')
+          .then(({ activeProvider }) => {
+            if (!mounted) return;
+            syncActiveProvider(activeProvider);
+          })
+          .catch((err) => {
+            logger.warn('Failed to load active provider, waiting for usable status:', err);
+          });
+
+        apiFetch<ProviderStatusData[]>('/settings/providers/status')
+          .then((statuses) => {
+            if (!mounted) return;
+
+            const statusMap = new Map(statuses.map((status) => [status.id, status]));
+            let nextActiveProviderId: string | null = null;
+
+            setProviders((prev) => {
+              const nextProviders = prev.map((provider) => {
+                const status = statusMap.get(provider.id);
+                return status
+                  ? {
+                      ...provider,
+                      installed: status.installed,
+                      authenticated: status.authenticated,
+                      binaryPath: status.binaryPath,
+                      version: status.version,
+                    }
+                  : provider;
+              });
+              nextActiveProviderId = findUsableProviderId(nextProviders, activeProviderIdRef.current);
+              return nextProviders;
+            });
+
+            if (nextActiveProviderId !== activeProviderIdRef.current) {
+              syncActiveProvider(nextActiveProviderId);
+            }
+          })
+          .catch((err) => {
             logger.warn('Failed to load provider statuses:', err);
           })
-          .finally(() => setStatusLoading(false));
+          .finally(() => {
+            if (mounted) {
+              setStatusLoading(false);
+            }
+          });
       })
       .catch((err: unknown) => {
+        if (!mounted) return;
         const message = err instanceof Error ? err.message : String(err);
         setError(message);
         setConfigLoading(false);
         setStatusLoading(false);
       });
-  }, []);
+
+    return () => {
+      mounted = false;
+    };
+  }, [syncActiveProvider]);
 
   // Sort providers by ranking
   const sortedProviders = [...providers].sort((a, b) => {
@@ -468,32 +527,53 @@ export function ProvidersSection() {
   });
 
   const handleSetActive = useCallback(async (id: string) => {
-    setActiveProviderId(id);
+    const previousActiveProviderId = activeProviderIdRef.current;
+    syncActiveProvider(id);
     try {
-      await apiFetch('/settings/provider', {
+      const response = await apiFetch<{ activeProvider: string }>('/settings/provider', {
         method: 'PUT',
         body: JSON.stringify({ id }),
       });
+      syncActiveProvider(response.activeProvider);
     } catch {
-      setActiveProviderId(activeProviderId);
+      syncActiveProvider(previousActiveProviderId);
     }
-  }, [activeProviderId]);
+  }, [syncActiveProvider]);
 
   const handleToggle = useCallback(async (id: string, enabled: boolean) => {
+    const previousActiveProviderId = activeProviderIdRef.current;
     setProviders((prev) =>
       prev.map((p) => (p.id === id ? { ...p, enabled } : p)),
     );
     try {
-      await apiFetch(`/settings/providers/${id}`, {
+      const response = await apiFetch<ProviderUpdateResponse>(`/settings/providers/${id}`, {
         method: 'PUT',
         body: JSON.stringify({ enabled }),
       });
+      setProviders((prev) =>
+        prev.map((provider) =>
+          provider.id === id
+            ? {
+                ...provider,
+                enabled: response.enabled,
+                installed: response.installed,
+                authenticated: response.authenticated,
+                binaryPath: response.binaryPath,
+                version: response.version,
+              }
+            : provider,
+        ),
+      );
+      if (response.activeProvider) {
+        syncActiveProvider(response.activeProvider);
+      }
     } catch {
       setProviders((prev) =>
         prev.map((p) => (p.id === id ? { ...p, enabled: !enabled } : p)),
       );
+      syncActiveProvider(previousActiveProviderId);
     }
-  }, []);
+  }, [syncActiveProvider]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/packages/web/src/components/Settings/ProvidersSection.tsx
+++ b/packages/web/src/components/Settings/ProvidersSection.tsx
@@ -105,12 +105,16 @@ function StatusBadgeSkeleton() {
 function ProviderCard({
   provider,
   rank,
+  isActive,
   onToggle,
+  onSetActive,
   statusLoading,
 }: {
   provider: ProviderStatus;
   rank: number;
+  isActive: boolean;
   onToggle: (id: string, enabled: boolean) => void;
+  onSetActive: (id: string) => void;
   statusLoading: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -193,6 +197,11 @@ function ProviderCard({
             <span className="text-[10px] font-mono text-th-text-muted w-4 text-center">{rank}</span>
             <span className="text-sm font-medium text-th-text-alt">{provider.name}</span>
             {providerDef?.isPreview && <PreviewBadge />}
+            {isActive && (
+              <span className="inline-flex items-center text-[10px] font-medium text-accent bg-accent/10 px-1.5 py-0.5 rounded-full" data-testid={`active-badge-${provider.id}`}>
+                Active
+              </span>
+            )}
             {statusLoading ? <StatusBadgeSkeleton /> : <StatusBadge {...providerStatusProps(provider)} />}
           </div>
           <div className="text-xs text-th-text-muted">
@@ -347,6 +356,16 @@ function ProviderCard({
 
           {/* Actions */}
           <div className="flex items-center gap-2 flex-wrap">
+            {/* Set as active */}
+            {provider.installed && !isActive && (
+              <button
+                onClick={() => onSetActive(provider.id)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-th-bg-hover text-th-text-alt hover:bg-th-bg-alt border border-th-border rounded-md transition-colors"
+                data-testid={`set-active-${provider.id}`}
+              >
+                Use this provider
+              </button>
+            )}
             {/* Test Connection */}
             {provider.installed && (
               <button
@@ -389,17 +408,20 @@ function ProviderCard({
 export function ProvidersSection() {
   const [providers, setProviders] = useState<ProviderStatus[]>([]);
   const [ranking, setRanking] = useState<string[]>([]);
+  const [activeProviderId, setActiveProviderId] = useState<string | null>(null);
   const [configLoading, setConfigLoading] = useState(true);
   const [statusLoading, setStatusLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Phase 1: Load config + ranking instantly (no CLI calls)
+  // Phase 1: Load config + ranking + active provider instantly (no CLI calls)
   useEffect(() => {
     Promise.all([
       apiFetch<ProviderConfig[]>('/settings/providers'),
       apiFetch<{ ranking: string[] }>('/settings/provider-ranking'),
+      apiFetch<{ activeProvider: string }>('/settings/provider'),
     ])
-      .then(([configs, { ranking: r }]) => {
+      .then(([configs, { ranking: r }, { activeProvider }]) => {
+        setActiveProviderId(activeProvider);
         // Build initial provider list from config (no status yet)
         setProviders(configs.map((c) => ({
           ...c,
@@ -444,6 +466,18 @@ export function ProvidersSection() {
     const bi = ranking.indexOf(b.id);
     return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi);
   });
+
+  const handleSetActive = useCallback(async (id: string) => {
+    setActiveProviderId(id);
+    try {
+      await apiFetch('/settings/provider', {
+        method: 'PUT',
+        body: JSON.stringify({ id }),
+      });
+    } catch {
+      setActiveProviderId(activeProviderId);
+    }
+  }, [activeProviderId]);
 
   const handleToggle = useCallback(async (id: string, enabled: boolean) => {
     setProviders((prev) =>
@@ -539,7 +573,9 @@ export function ProvidersSection() {
                   key={provider.id}
                   provider={provider}
                   rank={idx + 1}
+                  isActive={provider.id === activeProviderId}
                   onToggle={handleToggle}
+                  onSetActive={handleSetActive}
                   statusLoading={statusLoading}
                 />
               ))}

--- a/packages/web/src/components/Settings/ProvidersSection.tsx
+++ b/packages/web/src/components/Settings/ProvidersSection.tsx
@@ -550,39 +550,49 @@ export function ProvidersSection() {
   }, [syncActiveProvider]);
 
   const handleToggle = useCallback(async (id: string, enabled: boolean) => {
+    const previousProviders = providers;
     const previousActiveProviderId = activeProviderIdRef.current;
-    setProviders((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, enabled } : p)),
+    const nextProviders = previousProviders.map((provider) =>
+      provider.id === id ? { ...provider, enabled } : provider,
     );
+    const shouldSyncFallbackImmediately =
+      !enabled && !statusLoading && previousActiveProviderId === id;
+    const optimisticActiveProviderId = shouldSyncFallbackImmediately
+      ? findUsableProviderId(nextProviders, ranking, previousActiveProviderId)
+      : previousActiveProviderId;
+
+    setProviders(nextProviders);
+    if (optimisticActiveProviderId !== previousActiveProviderId) {
+      syncActiveProvider(optimisticActiveProviderId);
+    }
     try {
       const response = await apiFetch<ProviderUpdateResponse>(`/settings/providers/${id}`, {
         method: 'PUT',
         body: JSON.stringify({ enabled }),
       });
-      setProviders((prev) =>
-        prev.map((provider) =>
-          provider.id === id
-            ? {
-                ...provider,
-                enabled: response.enabled,
-                installed: response.installed,
-                authenticated: response.authenticated,
-                binaryPath: response.binaryPath,
-                version: response.version,
-              }
-            : provider,
-        ),
+      const persistedProviders = nextProviders.map((provider) =>
+        provider.id === id
+          ? {
+              ...provider,
+              enabled: response.enabled,
+              installed: response.installed,
+              authenticated: response.authenticated,
+              binaryPath: response.binaryPath,
+              version: response.version,
+            }
+          : provider,
       );
-      if (response.activeProvider) {
-        syncActiveProvider(response.activeProvider);
+      setProviders(persistedProviders);
+      const nextActiveProviderId = response.activeProvider
+        ?? findUsableProviderId(persistedProviders, ranking, optimisticActiveProviderId);
+      if (nextActiveProviderId !== activeProviderIdRef.current) {
+        syncActiveProvider(nextActiveProviderId);
       }
     } catch {
-      setProviders((prev) =>
-        prev.map((p) => (p.id === id ? { ...p, enabled: !enabled } : p)),
-      );
+      setProviders(previousProviders);
       syncActiveProvider(previousActiveProviderId);
     }
-  }, [syncActiveProvider]);
+  }, [providers, ranking, statusLoading, syncActiveProvider]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
+++ b/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
@@ -67,6 +67,16 @@ function mockProviderApisConfigOnly() {
     .mockReturnValueOnce(new Promise(() => {})); // status never resolves
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 // ── Tests ─────────────────────────────────────────────────
 
 describe('ProvidersSection', () => {
@@ -216,11 +226,16 @@ describe('ProvidersSection', () => {
       expect(screen.getByTestId('active-badge-codex')).toBeInTheDocument();
     });
 
-    mockApiFetch.mockResolvedValueOnce({
-      ...rankedStatuses[1],
-      enabled: false,
-      activeProvider: 'copilot',
-    });
+    const disableRequest = createDeferred<{
+      id: string;
+      installed: boolean;
+      authenticated: boolean | null;
+      binaryPath: string | null;
+      version: string | null;
+      enabled: boolean;
+      activeProvider: string;
+    }>();
+    mockApiFetch.mockReturnValueOnce(disableRequest.promise);
 
     fireEvent.click(screen.getByTestId('toggle-codex'));
 
@@ -229,6 +244,19 @@ describe('ProvidersSection', () => {
     });
     expect(screen.queryByTestId('active-badge-codex')).not.toBeInTheDocument();
     expect(mockUpdateCachedActiveProvider).toHaveBeenLastCalledWith('copilot');
+
+    disableRequest.resolve({
+      ...rankedStatuses[1],
+      enabled: false,
+      activeProvider: 'copilot',
+    });
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/settings/providers/codex',
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
   });
 
   it('calls API when setting a provider active', async () => {

--- a/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
+++ b/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
@@ -182,6 +182,55 @@ describe('ProvidersSection', () => {
     });
   });
 
+  it('updates the active badge immediately when disabling the active provider triggers a fallback', async () => {
+    const rankedConfigs = [
+      { id: 'copilot', name: 'GitHub Copilot SDK', enabled: true },
+      { id: 'codex', name: 'Codex CLI', enabled: true },
+      { id: 'claude', name: 'Claude Code', enabled: true },
+    ];
+    const rankedStatuses = [
+      { id: 'copilot', installed: true, authenticated: true, binaryPath: '/usr/bin/copilot', version: '1.0.0' },
+      { id: 'codex', installed: true, authenticated: true, binaryPath: '/usr/bin/codex', version: '0.5.0' },
+      { id: 'claude', installed: true, authenticated: true, binaryPath: '/usr/bin/claude', version: '2.1.0' },
+    ];
+
+    mockApiFetch
+      .mockResolvedValueOnce(rankedConfigs)
+      .mockResolvedValueOnce({ ranking: ['copilot', 'codex', 'claude'] })
+      .mockResolvedValueOnce({ activeProvider: 'copilot' })
+      .mockResolvedValueOnce(rankedStatuses);
+
+    render(<ProvidersSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-badge-copilot')).toBeInTheDocument();
+    });
+
+    const codexCard = screen.getByTestId('provider-card-codex');
+    fireEvent.click(codexCard.querySelector('[role="button"]')!);
+
+    mockApiFetch.mockResolvedValueOnce({ activeProvider: 'codex' });
+    fireEvent.click(screen.getByTestId('set-active-codex'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-badge-codex')).toBeInTheDocument();
+    });
+
+    mockApiFetch.mockResolvedValueOnce({
+      ...rankedStatuses[1],
+      enabled: false,
+      activeProvider: 'copilot',
+    });
+
+    fireEvent.click(screen.getByTestId('toggle-codex'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-badge-copilot')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('active-badge-codex')).not.toBeInTheDocument();
+    expect(mockUpdateCachedActiveProvider).toHaveBeenLastCalledWith('copilot');
+  });
+
   it('calls API when setting a provider active', async () => {
     mockProviderApis();
     render(<ProvidersSection />);

--- a/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
+++ b/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
@@ -39,15 +39,16 @@ const MOCK_STATUSES = [
 const MOCK_RANKING = {
   ranking: ['copilot', 'claude', 'gemini', 'opencode', 'cursor', 'codex', 'kimi', 'qwen-code'],
 };
+const MOCK_ACTIVE_PROVIDER = { activeProvider: 'copilot' };
 
 /**
- * Mock the two-phase loading: configs + ranking (Phase 1), then statuses (Phase 2).
- * Calls are: [0] /settings/providers, [1] /settings/provider-ranking, [2] /settings/providers/status
+ * Mock the startup loading: configs + ranking + active provider, then statuses.
  */
 function mockProviderApis() {
   mockApiFetch
     .mockResolvedValueOnce(MOCK_CONFIGS)
     .mockResolvedValueOnce(MOCK_RANKING)
+    .mockResolvedValueOnce(MOCK_ACTIVE_PROVIDER)
     .mockResolvedValueOnce(MOCK_STATUSES);
 }
 
@@ -58,6 +59,7 @@ function mockProviderApisConfigOnly() {
   mockApiFetch
     .mockResolvedValueOnce(MOCK_CONFIGS)
     .mockResolvedValueOnce(MOCK_RANKING)
+    .mockResolvedValueOnce(MOCK_ACTIVE_PROVIDER)
     .mockReturnValueOnce(new Promise(() => {})); // status never resolves
 }
 
@@ -115,6 +117,14 @@ describe('ProvidersSection', () => {
     });
   });
 
+  it('shows the active badge for the fetched active provider', async () => {
+    mockProviderApis();
+    render(<ProvidersSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('active-badge-copilot')).toBeInTheDocument();
+    });
+  });
+
   it('shows "Ready" badge for installed+authenticated providers', async () => {
     mockProviderApis();
     render(<ProvidersSection />);
@@ -163,6 +173,29 @@ describe('ProvidersSection', () => {
       expect(mockApiFetch).toHaveBeenCalledWith(
         '/settings/providers/copilot',
         expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+  });
+
+  it('calls API when setting a provider active', async () => {
+    mockProviderApis();
+    render(<ProvidersSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-list')).toBeInTheDocument();
+    });
+
+    const claudeCard = screen.getByTestId('provider-card-claude');
+    fireEvent.click(claudeCard.querySelector('[role="button"]')!);
+    mockApiFetch.mockResolvedValueOnce(undefined);
+    fireEvent.click(screen.getByTestId('set-active-claude'));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/settings/provider',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ id: 'claude' }),
+        }),
       );
     });
   });
@@ -216,6 +249,7 @@ describe('ProvidersSection', () => {
     mockApiFetch
       .mockResolvedValueOnce(MOCK_CONFIGS)
       .mockResolvedValueOnce(MOCK_RANKING)
+      .mockResolvedValueOnce(MOCK_ACTIVE_PROVIDER)
       .mockRejectedValueOnce(new Error('status timeout'));
     // Suppress expected warning from ProvidersSection error path
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
+++ b/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
@@ -6,8 +6,12 @@ import { ProvidersSection } from '../ProvidersSection';
 // ── Mocks ─────────────────────────────────────────────────
 
 const mockApiFetch = vi.fn();
+const mockUpdateCachedActiveProvider = vi.fn();
 vi.mock('../../../hooks/useApi', () => ({
   apiFetch: (...args: any[]) => mockApiFetch(...args),
+}));
+vi.mock('../../../hooks/useModels', () => ({
+  updateCachedActiveProvider: (...args: any[]) => mockUpdateCachedActiveProvider(...args),
 }));
 
 // ── Fixtures ──────────────────────────────────────────────
@@ -68,6 +72,7 @@ function mockProviderApisConfigOnly() {
 describe('ProvidersSection', () => {
   beforeEach(() => {
     mockApiFetch.mockReset();
+    mockUpdateCachedActiveProvider.mockReset();
   });
 
   it('renders loading state initially', () => {
@@ -117,11 +122,11 @@ describe('ProvidersSection', () => {
     });
   });
 
-  it('shows the active badge for the fetched active provider', async () => {
+  it('hydrates the cached active provider from startup data', async () => {
     mockProviderApis();
     render(<ProvidersSection />);
     await waitFor(() => {
-      expect(screen.getByTestId('active-badge-copilot')).toBeInTheDocument();
+      expect(mockUpdateCachedActiveProvider).toHaveBeenCalledWith('copilot');
     });
   });
 
@@ -167,7 +172,7 @@ describe('ProvidersSection', () => {
     await waitFor(() => {
       expect(screen.getByTestId('providers-list')).toBeInTheDocument();
     });
-    mockApiFetch.mockResolvedValueOnce({ ...MOCK_CONFIGS[0], enabled: false });
+    mockApiFetch.mockResolvedValueOnce({ ...MOCK_STATUSES[0], enabled: false, activeProvider: 'claude' });
     fireEvent.click(screen.getByTestId('toggle-copilot'));
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith(
@@ -186,7 +191,7 @@ describe('ProvidersSection', () => {
 
     const claudeCard = screen.getByTestId('provider-card-claude');
     fireEvent.click(claudeCard.querySelector('[role="button"]')!);
-    mockApiFetch.mockResolvedValueOnce(undefined);
+    mockApiFetch.mockResolvedValueOnce({ activeProvider: 'claude' });
     fireEvent.click(screen.getByTestId('set-active-claude'));
 
     await waitFor(() => {
@@ -198,6 +203,8 @@ describe('ProvidersSection', () => {
         }),
       );
     });
+    expect(screen.getByTestId('active-badge-claude')).toBeInTheDocument();
+    expect(mockUpdateCachedActiveProvider).toHaveBeenCalledWith('claude');
   });
 
   it('expands a card and shows test connection button', async () => {
@@ -261,6 +268,59 @@ describe('ProvidersSection', () => {
     expect(screen.getByText('GitHub Copilot SDK')).toBeInTheDocument();
     expect(screen.getByTestId('toggle-copilot')).toBeInTheDocument();
     spy.mockRestore();
+  });
+
+  it('still renders cards when provider ranking fetch fails', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce(MOCK_CONFIGS)
+      .mockRejectedValueOnce(new Error('ranking timeout'))
+      .mockResolvedValueOnce(MOCK_ACTIVE_PROVIDER)
+      .mockResolvedValueOnce(MOCK_STATUSES);
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await act(async () => { render(<ProvidersSection />); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-list')).toBeInTheDocument();
+    });
+
+    const cards = screen.getAllByTestId(/provider-card-/);
+    expect(cards[0]).toHaveAttribute('data-testid', 'provider-card-copilot');
+    expect(cards[1]).toHaveAttribute('data-testid', 'provider-card-claude');
+
+    spy.mockRestore();
+  });
+
+  it('still renders cards when active provider fetch fails', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce(MOCK_CONFIGS)
+      .mockResolvedValueOnce(MOCK_RANKING)
+      .mockRejectedValueOnce(new Error('active provider unavailable'))
+      .mockResolvedValueOnce(MOCK_STATUSES);
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await act(async () => { render(<ProvidersSection />); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-list')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('GitHub Copilot SDK')).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it('hides "Use this provider" for disabled installed providers', async () => {
+    mockProviderApis();
+    render(<ProvidersSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('providers-list')).toBeInTheDocument();
+    });
+
+    const cursorCard = screen.getByTestId('provider-card-cursor');
+    fireEvent.click(cursorCard.querySelector('[role="button"]')!);
+
+    expect(screen.queryByTestId('set-active-cursor')).not.toBeInTheDocument();
   });
 
   it('does not show preview badge for Codex', async () => {

--- a/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
+++ b/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
@@ -292,21 +292,46 @@ describe('ProvidersSection', () => {
   });
 
   it('still renders cards when active provider fetch fails', async () => {
+    const rankedConfigs = [
+      { id: 'copilot', name: 'GitHub Copilot SDK', enabled: true },
+      { id: 'claude', name: 'Claude Code', enabled: true },
+      { id: 'codex', name: 'Codex CLI', enabled: true },
+    ];
+    const rankedStatuses = [
+      { id: 'copilot', installed: true, authenticated: true, binaryPath: '/usr/bin/copilot', version: '1.0.0' },
+      { id: 'claude', installed: true, authenticated: true, binaryPath: '/usr/bin/claude', version: '2.1.0' },
+      { id: 'codex', installed: true, authenticated: true, binaryPath: '/usr/bin/codex', version: '0.5.0' },
+    ];
     mockApiFetch
-      .mockResolvedValueOnce(MOCK_CONFIGS)
-      .mockResolvedValueOnce(MOCK_RANKING)
+      .mockResolvedValueOnce(rankedConfigs)
+      .mockResolvedValueOnce({ ranking: ['codex', 'claude', 'copilot'] })
       .mockRejectedValueOnce(new Error('active provider unavailable'))
-      .mockResolvedValueOnce(MOCK_STATUSES);
+      .mockResolvedValueOnce(rankedStatuses);
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await act(async () => { render(<ProvidersSection />); });
 
     await waitFor(() => {
-      expect(screen.getByTestId('providers-list')).toBeInTheDocument();
+      expect(mockUpdateCachedActiveProvider).toHaveBeenCalledWith('codex');
     });
 
-    expect(screen.getByText('GitHub Copilot SDK')).toBeInTheDocument();
+    expect(screen.getByTestId('active-badge-codex')).toBeInTheDocument();
     spy.mockRestore();
+  });
+
+  it('falls back to the highest-ranked usable provider when the fetched active provider is unusable', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce(MOCK_CONFIGS)
+      .mockResolvedValueOnce({ ranking: ['claude', 'copilot', 'gemini', 'opencode', 'cursor', 'codex', 'kimi', 'qwen-code'] })
+      .mockResolvedValueOnce({ activeProvider: 'gemini' })
+      .mockResolvedValueOnce(MOCK_STATUSES);
+
+    render(<ProvidersSection />);
+
+    await waitFor(() => {
+      expect(mockUpdateCachedActiveProvider).toHaveBeenCalledWith('claude');
+    });
+    expect(screen.getByTestId('active-badge-claude')).toBeInTheDocument();
   });
 
   it('hides "Use this provider" for disabled installed providers', async () => {

--- a/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
+++ b/packages/web/src/components/Settings/__tests__/ProvidersSection.test.tsx
@@ -412,7 +412,21 @@ describe('ProvidersSection', () => {
   });
 
   it('hides "Use this provider" for disabled installed providers', async () => {
-    mockProviderApis();
+    const configs = MOCK_CONFIGS.map((provider) => (
+      provider.id === 'cursor' ? { ...provider, enabled: false } : provider
+    ));
+    const statuses = MOCK_STATUSES.map((provider) => (
+      provider.id === 'cursor'
+        ? { ...provider, installed: true, authenticated: true, binaryPath: '/usr/bin/cursor', version: '1.2.3' }
+        : provider
+    ));
+
+    mockApiFetch
+      .mockResolvedValueOnce(configs)
+      .mockResolvedValueOnce(MOCK_RANKING)
+      .mockResolvedValueOnce(MOCK_ACTIVE_PROVIDER)
+      .mockResolvedValueOnce(statuses);
+
     render(<ProvidersSection />);
 
     await waitFor(() => {
@@ -421,6 +435,10 @@ describe('ProvidersSection', () => {
 
     const cursorCard = screen.getByTestId('provider-card-cursor');
     fireEvent.click(cursorCard.querySelector('[role="button"]')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('test-connection-cursor')).toBeInTheDocument();
+    });
 
     expect(screen.queryByTestId('set-active-cursor')).not.toBeInTheDocument();
   });

--- a/packages/web/src/components/SetupWizard.tsx
+++ b/packages/web/src/components/SetupWizard.tsx
@@ -11,6 +11,11 @@ import {
   Loader2,
   ToggleLeft,
   ToggleRight,
+  User,
+  Users,
+  Shield,
+  Zap,
+  Scale,
 } from 'lucide-react';
 import { apiFetch } from '../hooks/useApi';
 import { getProvider } from '@flightdeck/shared';
@@ -42,7 +47,40 @@ interface ProviderView {
   authenticated: boolean | null;
 }
 
-type Step = 'welcome' | 'providers' | 'done';
+type Step = 'welcome' | 'providers' | 'preferences' | 'done';
+type UserType = 'personal' | 'team';
+type OversightLevel = 'supervised' | 'balanced' | 'autonomous';
+
+const USER_TYPE_CONFIG: Record<UserType, { defaultAgents: number; label: string; description: string }> = {
+  personal: {
+    defaultAgents: 5,
+    label: 'Personal / Solo',
+    description: 'Defaults to 5 concurrent agents — great for solo projects.',
+  },
+  team: {
+    defaultAgents: 50,
+    label: 'Team / Company',
+    description: 'Defaults to 50 concurrent agents — suited for larger codebases.',
+  },
+};
+
+const OVERSIGHT_CONFIG: Record<OversightLevel, { label: string; description: string; Icon: React.ElementType }> = {
+  supervised: {
+    label: 'Supervised',
+    description: 'Agents explain reasoning and show plans before acting',
+    Icon: Shield,
+  },
+  balanced: {
+    label: 'Balanced',
+    description: 'Explains key decisions, works efficiently on routine tasks',
+    Icon: Scale,
+  },
+  autonomous: {
+    label: 'Autonomous',
+    description: 'Works independently with minimal explanation — fewest tokens',
+    Icon: Zap,
+  },
+};
 
 const STORAGE_KEY = 'flightdeck-setup-completed';
 
@@ -50,10 +88,25 @@ const STORAGE_KEY = 'flightdeck-setup-completed';
 
 export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   const [step, setStep] = useState<Step>('welcome');
+  const [userType, setUserType] = useState<UserType | null>(null);
+  const [oversightLevel, setOversightLevel] = useState<OversightLevel | null>(null);
   const [providers, setProviders] = useState<ProviderView[]>([]);
   const [configLoading, setConfigLoading] = useState(true);
   const [statusLoading, setStatusLoading] = useState(true);
   const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const applyPreferences = useCallback(async (type: UserType, oversight: OversightLevel) => {
+    try {
+      await apiFetch('/config', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          maxConcurrentAgents: USER_TYPE_CONFIG[type].defaultAgents,
+          oversightLevel: oversight,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch { /* non-blocking — user can adjust in Settings */ }
+  }, []);
 
   // Phase 1: instant config (id, name, enabled)
   useEffect(() => {
@@ -112,6 +165,13 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   const installedCount = providers.filter((p) => p.installed === true).length;
   const enabledCount = providers.filter((p) => p.enabled).length;
 
+  const handlePreferencesContinue = async () => {
+    const type = userType ?? 'personal';
+    const oversight = oversightLevel ?? 'autonomous';
+    await applyPreferences(type, oversight);
+    setStep('done');
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
@@ -141,9 +201,8 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
               <Rocket className="w-12 h-12 text-accent mx-auto" />
               <h3 className="text-lg font-semibold text-th-text">Welcome to Flightdeck!</h3>
               <p className="text-sm text-th-text-muted leading-relaxed">
-                Let's check your AI agent providers. Flightdeck orchestrates
-                multiple AI coding agents — you'll need at least one provider
-                installed to get started.
+                Let's get you set up. We'll check your AI agent providers and
+                configure a few defaults to match how you work.
               </p>
             </div>
           )}
@@ -247,6 +306,72 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
             </div>
           )}
 
+          {step === 'preferences' && (
+            <div className="space-y-5" data-testid="step-preferences">
+              {/* User type */}
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-th-text-muted uppercase tracking-wide">How will you use Flightdeck?</p>
+                <div className="grid grid-cols-2 gap-2">
+                  {(['personal', 'team'] as UserType[]).map((type) => {
+                    const cfg = USER_TYPE_CONFIG[type];
+                    const selected = userType === type;
+                    return (
+                      <button
+                        key={type}
+                        onClick={() => setUserType(type)}
+                        className={`flex items-center gap-3 rounded-lg border-2 px-3 py-3 transition-colors text-left ${
+                          selected
+                            ? 'border-accent bg-accent/10 text-th-text'
+                            : 'border-th-border bg-th-bg-alt text-th-text-muted hover:border-th-border-alt hover:text-th-text'
+                        }`}
+                        data-testid={`user-type-${type}`}
+                      >
+                        {type === 'personal'
+                          ? <User className={`w-5 h-5 flex-shrink-0 ${selected ? 'text-accent' : ''}`} />
+                          : <Users className={`w-5 h-5 flex-shrink-0 ${selected ? 'text-accent' : ''}`} />
+                        }
+                        <div>
+                          <div className="text-xs font-semibold">{cfg.label}</div>
+                          <div className="text-[11px] leading-relaxed">{cfg.description}</div>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Oversight level */}
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-th-text-muted uppercase tracking-wide">Oversight level</p>
+                <div className="grid grid-cols-3 gap-2">
+                  {(['supervised', 'balanced', 'autonomous'] as OversightLevel[]).map((level) => {
+                    const cfg = OVERSIGHT_CONFIG[level];
+                    const selected = oversightLevel === level;
+                    return (
+                      <button
+                        key={level}
+                        onClick={() => setOversightLevel(level)}
+                        className={`flex flex-col items-center gap-2 rounded-lg border-2 px-2 py-3 transition-colors text-center ${
+                          selected
+                            ? 'border-accent bg-accent/10 text-th-text'
+                            : 'border-th-border bg-th-bg-alt text-th-text-muted hover:border-th-border-alt hover:text-th-text'
+                        }`}
+                        data-testid={`oversight-${level}`}
+                      >
+                        <cfg.Icon className={`w-4 h-4 ${selected ? 'text-accent' : ''}`} />
+                        <div>
+                          <div className="text-xs font-semibold">{cfg.label}</div>
+                          <div className="text-[10px] leading-relaxed mt-0.5">{cfg.description}</div>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="text-[11px] text-th-text-muted">Defaults to Autonomous if not selected. Adjustable any time in Settings.</p>
+              </div>
+            </div>
+          )}
+
           {step === 'done' && (
             <div className="text-center space-y-4" data-testid="step-done">
               <CheckCircle className="w-12 h-12 text-green-400 mx-auto" />
@@ -256,6 +381,21 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
                   ? `${enabledCount} provider${enabledCount > 1 ? 's' : ''} enabled. Create your first project to start working with AI agents.`
                   : 'You can set up providers later in Settings. Create a project to explore the interface.'}
               </p>
+              {(userType || oversightLevel) && (
+                <div className="text-xs text-th-text-muted space-y-1">
+                  {userType && (
+                    <p>
+                      <span className="text-th-text font-medium">{USER_TYPE_CONFIG[userType].label}</span>
+                      {' '}— {USER_TYPE_CONFIG[userType].defaultAgents} agents by default
+                    </p>
+                  )}
+                  {oversightLevel && (
+                    <p>
+                      Oversight: <span className="text-th-text font-medium">{OVERSIGHT_CONFIG[oversightLevel].label}</span>
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -272,7 +412,11 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
           <div className="flex items-center gap-2">
             {step !== 'welcome' && (
               <button
-                onClick={() => setStep(step === 'done' ? 'providers' : 'welcome')}
+                onClick={() => {
+                  if (step === 'done') setStep('preferences');
+                  else if (step === 'preferences') setStep('providers');
+                  else setStep('welcome');
+                }}
                 className="flex items-center gap-1 px-3 py-1.5 text-xs text-th-text-muted hover:text-th-text border border-th-border rounded"
                 data-testid="wizard-back"
               >
@@ -288,13 +432,22 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
               >
                 Get Started
               </button>
-            ) : (
+            ) : step === 'preferences' ? (
               <button
-                onClick={() => setStep(step === 'welcome' ? 'providers' : 'done')}
+                onClick={handlePreferencesContinue}
                 className="flex items-center gap-1 px-4 py-1.5 text-xs font-medium bg-accent/20 text-accent hover:bg-accent/30 border border-accent/30 rounded"
                 data-testid="wizard-next"
               >
-                {step === 'welcome' ? 'Check Providers' : 'Continue'}
+                Continue
+                <ChevronRight className="w-3 h-3" />
+              </button>
+            ) : (
+              <button
+                onClick={() => setStep(step === 'welcome' ? 'providers' : 'preferences')}
+                className="flex items-center gap-1 px-4 py-1.5 text-xs font-medium bg-accent/20 text-accent hover:bg-accent/30 border border-accent/30 rounded"
+                data-testid="wizard-next"
+              >
+                {step === 'welcome' ? 'Get Started' : 'Continue'}
                 <ChevronRight className="w-3 h-3" />
               </button>
             )}

--- a/packages/web/src/components/SetupWizard.tsx
+++ b/packages/web/src/components/SetupWizard.tsx
@@ -16,7 +16,12 @@ import {
   Shield,
   Zap,
   Scale,
+  GripVertical,
 } from 'lucide-react';
+import { DndContext, closestCenter, PointerSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { apiFetch } from '../hooks/useApi';
 import { getProvider } from '@flightdeck/shared';
 import { ProviderIcon } from './ui/ProviderIcon';
@@ -84,6 +89,113 @@ const OVERSIGHT_CONFIG: Record<OversightLevel, { label: string; description: str
 
 const STORAGE_KEY = 'flightdeck-setup-completed';
 
+// ── Sortable Provider Row ────────────────────────────────────────────
+
+function SortableProviderRow({
+  provider,
+  togglingId,
+  onToggle,
+}: {
+  provider: ProviderView;
+  togglingId: string | null;
+  onToggle: (id: string, enabled: boolean) => void;
+}) {
+  const def = getProvider(provider.id);
+  const links = def?.setupLinks ?? [];
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: provider.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded-lg border bg-th-bg-alt transition-opacity ${
+        provider.enabled ? 'border-th-border' : 'border-th-border/50 opacity-60'
+      }`}
+      data-testid={`provider-${provider.id}`}
+    >
+      <div className="flex items-center justify-between px-3 py-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <button
+            {...attributes}
+            {...listeners}
+            className="touch-none p-0.5 text-th-text-muted/40 hover:text-th-text-muted cursor-grab active:cursor-grabbing transition-colors shrink-0"
+            aria-label={`Drag to reorder ${provider.name}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <GripVertical className="w-4 h-4" />
+          </button>
+          <span className="text-lg flex-shrink-0"><ProviderIcon provider={def} className="w-5 h-5 inline" /></span>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-th-text">{provider.name}</span>
+              {(def?.isPreview ?? true) && (
+                <span className="inline-flex items-center text-[10px] font-medium text-blue-400 bg-blue-500/10 px-1.5 py-0.5 rounded-full">
+                  Preview
+                </span>
+              )}
+            </div>
+            {provider.id === 'copilot' && (
+              <div className="text-[10px] text-th-text-muted">Requires Copilot ≥ 1.0.4</div>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {provider.installed === null ? (
+            <Loader2 className="w-3.5 h-3.5 text-th-text-muted animate-spin" />
+          ) : provider.installed ? (
+            <span className="flex items-center gap-1 text-xs text-green-400">
+              <CheckCircle className="w-3.5 h-3.5" />
+              Installed
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 text-xs text-th-text-muted">
+              <XCircle className="w-3.5 h-3.5" />
+              Not found
+            </span>
+          )}
+          <button
+            onClick={() => onToggle(provider.id, !provider.enabled)}
+            disabled={togglingId === provider.id}
+            className="text-th-text-muted hover:text-th-text transition-colors disabled:opacity-50"
+            aria-label={provider.enabled ? `Disable ${provider.name}` : `Enable ${provider.name}`}
+            data-testid={`toggle-${provider.id}`}
+          >
+            {provider.enabled ? (
+              <ToggleRight className="w-6 h-6 text-accent" />
+            ) : (
+              <ToggleLeft className="w-6 h-6" />
+            )}
+          </button>
+        </div>
+      </div>
+      {links.length > 0 && (
+        <div className="flex items-center gap-3 px-4 pb-2.5 -mt-1">
+          {links.map((link) => (
+            <a
+              key={link.url}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-[11px] text-accent hover:underline"
+            >
+              {link.label}
+              <ExternalLink className="w-2.5 h-2.5" />
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Component ───────────────────────────────────────────────────────
 
 export function SetupWizard({ onComplete }: { onComplete: () => void }) {
@@ -91,6 +203,7 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   const [userType, setUserType] = useState<UserType | null>(null);
   const [oversightLevel, setOversightLevel] = useState<OversightLevel | null>(null);
   const [providers, setProviders] = useState<ProviderView[]>([]);
+  const [ranking, setRanking] = useState<string[]>([]);
   const [configLoading, setConfigLoading] = useState(true);
   const [statusLoading, setStatusLoading] = useState(true);
   const [togglingId, setTogglingId] = useState<string | null>(null);
@@ -108,14 +221,18 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
     } catch { /* non-blocking — user can adjust in Settings */ }
   }, []);
 
-  // Phase 1: instant config (id, name, enabled)
+  // Phase 1: instant config (id, name, enabled) + ranking
   useEffect(() => {
-    apiFetch<ProviderConfig[]>('/settings/providers')
-      .then((configs) => {
+    Promise.all([
+      apiFetch<ProviderConfig[]>('/settings/providers'),
+      apiFetch<{ ranking: string[] }>('/settings/provider-ranking'),
+    ])
+      .then(([configs, { ranking: r }]) => {
         setProviders(configs.map((c) => ({
           id: c.id, name: c.name, enabled: c.enabled,
           installed: null, authenticated: null,
         })));
+        setRanking(r);
       })
       .catch(() => { /* initial fetch — will retry */ })
       .finally(() => setConfigLoading(false));
@@ -161,6 +278,35 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
       setTogglingId(null);
     }
   }, []);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = ranking.indexOf(active.id as string);
+    const newIndex = ranking.indexOf(over.id as string);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const newRanking = arrayMove(ranking, oldIndex, newIndex);
+    setRanking(newRanking);
+    try {
+      await apiFetch('/settings/provider-ranking', {
+        method: 'PUT',
+        body: JSON.stringify({ ranking: newRanking }),
+      });
+    } catch {
+      setRanking(ranking);
+    }
+  }, [ranking]);
+
+  const sortedProviders = [...providers].sort((a, b) => {
+    const ai = ranking.indexOf(a.id);
+    const bi = ranking.indexOf(b.id);
+    return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi);
+  });
 
   const installedCount = providers.filter((p) => p.installed === true).length;
   const enabledCount = providers.filter((p) => p.enabled).length;
@@ -213,7 +359,7 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
                 {statusLoading
                   ? 'Detecting providers…'
                   : installedCount > 0
-                    ? `${installedCount} of ${providers.length} providers detected. Toggle to enable or disable.`
+                    ? `${installedCount} of ${providers.length} providers detected. Drag to reorder, toggle to enable or disable.`
                     : 'No providers detected. Install at least one to start.'}
               </p>
               {configLoading ? (
@@ -221,87 +367,20 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
                   <div className="w-5 h-5 border-2 border-th-text-muted/30 border-t-accent rounded-full animate-spin" />
                 </div>
               ) : (
-                <div className="space-y-2 max-h-[360px] overflow-y-auto">
-                  {providers.map((p) => {
-                    const def = getProvider(p.id);
-                    const links = def?.setupLinks ?? [];
-                    return (
-                      <div
-                        key={p.id}
-                        className={`rounded-lg border bg-th-bg-alt transition-opacity ${
-                          p.enabled ? 'border-th-border' : 'border-th-border/50 opacity-60'
-                        }`}
-                        data-testid={`provider-${p.id}`}
-                      >
-                        <div className="flex items-center justify-between px-4 py-3">
-                          <div className="flex items-center gap-3 min-w-0">
-                            <span className="text-lg flex-shrink-0"><ProviderIcon provider={def} className="w-5 h-5 inline" /></span>
-                            <div className="min-w-0">
-                              <div className="flex items-center gap-2">
-                                <span className="text-sm font-medium text-th-text">{p.name}</span>
-                                {(def?.isPreview ?? true) && (
-                                  <span className="inline-flex items-center text-[10px] font-medium text-blue-400 bg-blue-500/10 px-1.5 py-0.5 rounded-full">
-                                    Preview
-                                  </span>
-                                )}
-                              </div>
-                              {p.id === 'copilot' && (
-                                <div className="text-[10px] text-th-text-muted">Requires Copilot ≥ 1.0.4</div>
-                              )}
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-3 flex-shrink-0">
-                            {/* Install status badge */}
-                            {p.installed === null ? (
-                              <Loader2 className="w-3.5 h-3.5 text-th-text-muted animate-spin" />
-                            ) : p.installed ? (
-                              <span className="flex items-center gap-1 text-xs text-green-400">
-                                <CheckCircle className="w-3.5 h-3.5" />
-                                Installed
-                              </span>
-                            ) : (
-                              <span className="flex items-center gap-1 text-xs text-th-text-muted">
-                                <XCircle className="w-3.5 h-3.5" />
-                                Not found
-                              </span>
-                            )}
-                            {/* Enable/disable toggle */}
-                            <button
-                              onClick={() => handleToggle(p.id, !p.enabled)}
-                              disabled={togglingId === p.id}
-                              className="text-th-text-muted hover:text-th-text transition-colors disabled:opacity-50"
-                              aria-label={p.enabled ? `Disable ${p.name}` : `Enable ${p.name}`}
-                              data-testid={`toggle-${p.id}`}
-                            >
-                              {p.enabled ? (
-                                <ToggleRight className="w-6 h-6 text-accent" />
-                              ) : (
-                                <ToggleLeft className="w-6 h-6" />
-                              )}
-                            </button>
-                          </div>
-                        </div>
-                        {/* Setup links (always visible for providers needing CLI + adapter) */}
-                        {links.length > 0 && (
-                          <div className="flex items-center gap-3 px-4 pb-2.5 -mt-1">
-                            {links.map((link) => (
-                              <a
-                                key={link.url}
-                                href={link.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="flex items-center gap-1 text-[11px] text-accent hover:underline"
-                              >
-                                {link.label}
-                                <ExternalLink className="w-2.5 h-2.5" />
-                              </a>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
+                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                  <SortableContext items={ranking} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-2 max-h-[360px] overflow-y-auto">
+                      {sortedProviders.map((p) => (
+                        <SortableProviderRow
+                          key={p.id}
+                          provider={p}
+                          togglingId={togglingId}
+                          onToggle={handleToggle}
+                        />
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
               )}
             </div>
           )}

--- a/packages/web/src/components/SetupWizard.tsx
+++ b/packages/web/src/components/SetupWizard.tsx
@@ -27,6 +27,7 @@ import { useAppStore } from '../stores/appStore';
 import { useSettingsStore } from '../stores/settingsStore';
 import { getProvider } from '@flightdeck/shared';
 import { ProviderIcon } from './ui/ProviderIcon';
+import { normalizeProviderRanking } from './providerPreferences';
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -52,6 +53,16 @@ interface ProviderView {
   enabled: boolean;
   installed: boolean | null;  // null = still detecting
   authenticated: boolean | null;
+}
+
+function buildProviderViews(configs: ProviderConfig[]): ProviderView[] {
+  return configs.map((config) => ({
+    id: config.id,
+    name: config.name,
+    enabled: config.enabled,
+    installed: null,
+    authenticated: null,
+  }));
 }
 
 type Step = 'welcome' | 'providers' | 'preferences' | 'done';
@@ -228,26 +239,39 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
 
   // Phase 1: instant config (id, name, enabled) + ranking
   useEffect(() => {
-    Promise.all([
-      apiFetch<ProviderConfig[]>('/settings/providers'),
-      apiFetch<{ ranking: string[] }>('/settings/provider-ranking'),
-    ])
-      .then(([configs, { ranking: r }]) => {
-        setProviders(configs.map((c) => ({
-          id: c.id, name: c.name, enabled: c.enabled,
-          installed: null, authenticated: null,
-        })));
-        setRanking(r);
+    let mounted = true;
+
+    apiFetch<ProviderConfig[]>('/settings/providers')
+      .then((configs) => {
+        if (!mounted) return;
+        setProviders(buildProviderViews(configs));
+        setRanking(normalizeProviderRanking(configs));
+        setConfigLoading(false);
+
+        apiFetch<{ ranking: string[] }>('/settings/provider-ranking')
+          .then(({ ranking: nextRanking }) => {
+            if (!mounted) return;
+            setRanking(normalizeProviderRanking(configs, nextRanking));
+          })
+          .catch(() => { /* ranking preference is optional in setup wizard */ });
       })
-      .catch(() => { /* initial fetch — will retry */ })
-      .finally(() => setConfigLoading(false));
+      .catch(() => {
+        if (!mounted) return;
+        setConfigLoading(false);
+        setStatusLoading(false);
+      });
+
+    return () => { mounted = false; };
   }, []);
 
   // Phase 2: async CLI detection (installed, authenticated)
   useEffect(() => {
     if (configLoading) return;
+    let mounted = true;
+
     apiFetch<ProviderStatusData[]>('/settings/providers/status')
       .then((statuses) => {
+        if (!mounted) return;
         const statusMap = new Map(statuses.map((s) => [s.id, s]));
         setProviders((prev) =>
           prev.map((p) => {
@@ -257,7 +281,11 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
         );
       })
       .catch(() => { /* status detection failed — badges stay as loading */ })
-      .finally(() => setStatusLoading(false));
+      .finally(() => {
+        if (mounted) setStatusLoading(false);
+      });
+
+    return () => { mounted = false; };
   }, [configLoading]);
 
   const handleDismiss = useCallback(() => {
@@ -542,7 +570,7 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   );
 }
 
-/** Check if the setup wizard should be shown (no providers configured + not dismissed). */
+/** Check if the setup wizard has been dismissed in local storage. */
 export function shouldShowSetupWizard(): boolean {
   try { return localStorage.getItem(STORAGE_KEY) !== 'true'; } catch { return true; }
 }

--- a/packages/web/src/components/SetupWizard.tsx
+++ b/packages/web/src/components/SetupWizard.tsx
@@ -23,6 +23,8 @@ import type { DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { apiFetch } from '../hooks/useApi';
+import { useAppStore } from '../stores/appStore';
+import { useSettingsStore } from '../stores/settingsStore';
 import { getProvider } from '@flightdeck/shared';
 import { ProviderIcon } from './ui/ProviderIcon';
 
@@ -209,13 +211,16 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
   const [togglingId, setTogglingId] = useState<string | null>(null);
 
   const applyPreferences = useCallback(async (type: UserType, oversight: OversightLevel) => {
+    const maxConcurrentAgents = USER_TYPE_CONFIG[type].defaultAgents;
+    useSettingsStore.getState().setOversightLevel(oversight);
+    const currentConfig = useAppStore.getState().config;
+    if (currentConfig) {
+      useAppStore.getState().setConfig({ ...currentConfig, maxConcurrentAgents });
+    }
     try {
       await apiFetch('/config', {
         method: 'PATCH',
-        body: JSON.stringify({
-          maxConcurrentAgents: USER_TYPE_CONFIG[type].defaultAgents,
-          oversightLevel: oversight,
-        }),
+        body: JSON.stringify({ maxConcurrentAgents, oversightLevel: oversight }),
         headers: { 'Content-Type': 'application/json' },
       });
     } catch { /* non-blocking — user can adjust in Settings */ }

--- a/packages/web/src/components/__tests__/SetupWizard.test.tsx
+++ b/packages/web/src/components/__tests__/SetupWizard.test.tsx
@@ -50,12 +50,45 @@ const MOCK_STATUSES = [
 ];
 
 const ALL_NOT_INSTALLED_STATUSES = MOCK_STATUSES.map((s) => ({ ...s, installed: false, binaryPath: null }));
+const MOCK_RANKING = { ranking: MOCK_CONFIGS.map(({ id }) => id) };
 
-function mockTwoPhase(configs = MOCK_CONFIGS, statuses = MOCK_STATUSES) {
+function mockWizardApis({
+  configs = MOCK_CONFIGS,
+  statuses = MOCK_STATUSES,
+  ranking = MOCK_RANKING,
+}: {
+  configs?: typeof MOCK_CONFIGS;
+  statuses?: typeof MOCK_STATUSES;
+  ranking?: { ranking: string[] };
+} = {}) {
   mockApiFetch.mockImplementation((url: string) => {
     if (url === '/settings/providers') return Promise.resolve(configs);
+    if (url === '/settings/provider-ranking') return Promise.resolve(ranking);
     if (url === '/settings/providers/status') return Promise.resolve(statuses);
     return Promise.resolve(undefined);
+  });
+}
+
+async function goToProvidersStep() {
+  fireEvent.click(screen.getByTestId('wizard-next'));
+  await waitFor(() => {
+    expect(screen.getByTestId('step-providers')).toBeInTheDocument();
+  });
+}
+
+async function goToPreferencesStep() {
+  await goToProvidersStep();
+  fireEvent.click(screen.getByTestId('wizard-next'));
+  await waitFor(() => {
+    expect(screen.getByTestId('step-preferences')).toBeInTheDocument();
+  });
+}
+
+async function goToDoneStep() {
+  await goToPreferencesStep();
+  fireEvent.click(screen.getByTestId('wizard-next'));
+  await waitFor(() => {
+    expect(screen.getByTestId('step-done')).toBeInTheDocument();
   });
 }
 
@@ -71,7 +104,7 @@ describe('SetupWizard', () => {
   });
 
   it('renders welcome step initially', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
     expect(screen.getByTestId('setup-wizard')).toBeInTheDocument();
@@ -80,14 +113,10 @@ describe('SetupWizard', () => {
   });
 
   it('navigates to providers step and shows installed count after detection', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    fireEvent.click(screen.getByTestId('wizard-next'));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('step-providers')).toBeInTheDocument();
-    });
+    await goToProvidersStep();
 
     // After status loads, should show installed count
     await waitFor(() => {
@@ -96,11 +125,10 @@ describe('SetupWizard', () => {
   });
 
   it('shows installed status for configured providers', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    fireEvent.click(screen.getByTestId('wizard-next'));
-
+    await goToProvidersStep();
     await waitFor(() => {
       expect(screen.getByTestId('provider-copilot')).toBeInTheDocument();
     });
@@ -113,50 +141,46 @@ describe('SetupWizard', () => {
   });
 
   it('shows no providers message when none detected', async () => {
-    mockTwoPhase(MOCK_CONFIGS, ALL_NOT_INSTALLED_STATUSES);
+    mockWizardApis({ configs: MOCK_CONFIGS, statuses: ALL_NOT_INSTALLED_STATUSES });
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    fireEvent.click(screen.getByTestId('wizard-next'));
-
+    await goToProvidersStep();
     await waitFor(() => {
       expect(screen.getByText(/no providers detected/i)).toBeInTheDocument();
     });
   });
 
-  it('navigates through all three steps', async () => {
-    mockTwoPhase();
+  it('navigates through welcome, providers, preferences, and done steps', async () => {
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    // Step 1: Welcome
     expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
+    await goToProvidersStep();
     fireEvent.click(screen.getByTestId('wizard-next'));
-
-    // Step 2: Providers
     await waitFor(() => {
-      expect(screen.getByTestId('step-providers')).toBeInTheDocument();
+      expect(screen.getByTestId('step-preferences')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('wizard-next'));
+    await waitFor(() => {
+      expect(screen.getByTestId('step-done')).toBeInTheDocument();
+    });
 
-    // Step 3: Done
     expect(screen.getByTestId('step-done')).toBeInTheDocument();
     expect(screen.getByText(/you're ready/i)).toBeInTheDocument();
   });
 
   it('back button navigates to previous step', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    fireEvent.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => {
-      expect(screen.getByTestId('step-providers')).toBeInTheDocument();
-    });
+    await goToProvidersStep();
 
     fireEvent.click(screen.getByTestId('wizard-back'));
     expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
   });
 
   it('dismiss sets localStorage and calls onComplete', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
     fireEvent.click(screen.getByTestId('wizard-dismiss'));
@@ -165,7 +189,7 @@ describe('SetupWizard', () => {
   });
 
   it('skip sets localStorage and calls onComplete', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
     fireEvent.click(screen.getByTestId('wizard-skip'));
@@ -174,24 +198,43 @@ describe('SetupWizard', () => {
   });
 
   it('finish on done step sets localStorage and calls onComplete', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    // Navigate to done
-    fireEvent.click(screen.getByTestId('wizard-next'));
-    await waitFor(() => screen.getByTestId('step-providers'));
-    fireEvent.click(screen.getByTestId('wizard-next'));
+    await goToDoneStep();
 
     fireEvent.click(screen.getByTestId('wizard-finish'));
     expect(localStorage.getItem('flightdeck-setup-completed')).toBe('true');
     expect(onComplete).toHaveBeenCalled();
   });
 
-  it('shows setup links for providers with multiple links', async () => {
-    mockTwoPhase();
+  it('applies selected preferences before continuing to done', async () => {
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
+    await goToPreferencesStep();
+
+    fireEvent.click(screen.getByTestId('user-type-team'));
+    fireEvent.click(screen.getByTestId('oversight-balanced'));
     fireEvent.click(screen.getByTestId('wizard-next'));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        '/config',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ maxConcurrentAgents: 50, oversightLevel: 'balanced' }),
+        }),
+      );
+    });
+    expect(screen.getByTestId('step-done')).toBeInTheDocument();
+  });
+
+  it('shows setup links for providers with multiple links', async () => {
+    mockWizardApis();
+    await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
+
+    await goToProvidersStep();
     await waitFor(() => screen.getByTestId('provider-claude'));
 
     // Claude should show ACP adapter link
@@ -201,10 +244,10 @@ describe('SetupWizard', () => {
   });
 
   it('enable/disable toggle calls API and updates UI', async () => {
-    mockTwoPhase();
+    mockWizardApis();
     await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
 
-    fireEvent.click(screen.getByTestId('wizard-next'));
+    await goToProvidersStep();
     await waitFor(() => screen.getByTestId('toggle-copilot'));
 
     // Toggle copilot off

--- a/packages/web/src/components/__tests__/SetupWizard.test.tsx
+++ b/packages/web/src/components/__tests__/SetupWizard.test.tsx
@@ -56,14 +56,18 @@ function mockWizardApis({
   configs = MOCK_CONFIGS,
   statuses = MOCK_STATUSES,
   ranking = MOCK_RANKING,
+  rankingError,
 }: {
   configs?: typeof MOCK_CONFIGS;
   statuses?: typeof MOCK_STATUSES;
   ranking?: { ranking: string[] };
+  rankingError?: Error;
 } = {}) {
   mockApiFetch.mockImplementation((url: string) => {
     if (url === '/settings/providers') return Promise.resolve(configs);
-    if (url === '/settings/provider-ranking') return Promise.resolve(ranking);
+    if (url === '/settings/provider-ranking') {
+      return rankingError ? Promise.reject(rankingError) : Promise.resolve(ranking);
+    }
     if (url === '/settings/providers/status') return Promise.resolve(statuses);
     return Promise.resolve(undefined);
   });
@@ -148,6 +152,21 @@ describe('SetupWizard', () => {
     await waitFor(() => {
       expect(screen.getByText(/no providers detected/i)).toBeInTheDocument();
     });
+  });
+
+  it('keeps provider setup usable when ranking fetch fails', async () => {
+    mockWizardApis({ rankingError: new Error('ranking unavailable') });
+    await act(async () => { render(<SetupWizard onComplete={onComplete} />); });
+
+    await goToProvidersStep();
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 of 8 providers detected/i)).toBeInTheDocument();
+    });
+
+    const providerRows = screen.getAllByTestId(/provider-/);
+    expect(providerRows[0]).toHaveAttribute('data-testid', 'provider-copilot');
+    expect(providerRows[1]).toHaveAttribute('data-testid', 'provider-claude');
   });
 
   it('navigates through welcome, providers, preferences, and done steps', async () => {

--- a/packages/web/src/components/providerPreferences.ts
+++ b/packages/web/src/components/providerPreferences.ts
@@ -22,6 +22,7 @@ export function normalizeProviderRanking<T extends ProviderWithId>(
 
 export function findUsableProviderId<T extends UsableProvider>(
   providers: T[],
+  ranking?: string[],
   preferredId?: string | null,
 ): string | null {
   if (preferredId) {
@@ -31,5 +32,12 @@ export function findUsableProviderId<T extends UsableProvider>(
     }
   }
 
-  return providers.find((provider) => provider.enabled && provider.installed === true)?.id ?? null;
+  const usableProviders = providers.filter((provider) => provider.enabled && provider.installed === true);
+  if (usableProviders.length === 0) {
+    return null;
+  }
+
+  const rankingOrder = normalizeProviderRanking(providers, ranking);
+  const usableProviderIds = new Set(usableProviders.map((provider) => provider.id));
+  return rankingOrder.find((providerId) => usableProviderIds.has(providerId)) ?? usableProviders[0]?.id ?? null;
 }

--- a/packages/web/src/components/providerPreferences.ts
+++ b/packages/web/src/components/providerPreferences.ts
@@ -1,0 +1,35 @@
+interface ProviderWithId {
+  id: string;
+}
+
+interface UsableProvider {
+  id: string;
+  enabled: boolean;
+  installed: boolean | null;
+}
+
+export function normalizeProviderRanking<T extends ProviderWithId>(
+  providers: T[],
+  ranking?: string[],
+): string[] {
+  const knownIds = new Set(providers.map((provider) => provider.id));
+  const preferred = (ranking ?? []).filter((id) => knownIds.has(id));
+  const missing = providers
+    .map((provider) => provider.id)
+    .filter((id) => !preferred.includes(id));
+  return [...preferred, ...missing];
+}
+
+export function findUsableProviderId<T extends UsableProvider>(
+  providers: T[],
+  preferredId?: string | null,
+): string | null {
+  if (preferredId) {
+    const preferredProvider = providers.find((provider) => provider.id === preferredId);
+    if (preferredProvider?.enabled && preferredProvider.installed === true) {
+      return preferredId;
+    }
+  }
+
+  return providers.find((provider) => provider.enabled && provider.installed === true)?.id ?? null;
+}

--- a/packages/web/src/hooks/__tests__/useModels.test.ts
+++ b/packages/web/src/hooks/__tests__/useModels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { useModels, _resetModelsCache, deriveModelName } from '../useModels';
+import { useModels, _resetModelsCache, deriveModelName, updateCachedActiveProvider } from '../useModels';
 
 const mockApiFetch = vi.fn();
 vi.mock('../useApi', () => ({
@@ -76,6 +76,23 @@ describe('useModels', () => {
 
     expect(result.current.modelsByProvider).toEqual(MOCK_RESPONSE.modelsByProvider);
     expect(result.current.activeProvider).toBe('claude');
+  });
+
+  it('updates cached consumers immediately when the active provider changes', async () => {
+    mockApiFetch.mockResolvedValue(MOCK_RESPONSE);
+
+    const { result } = renderHook(() => useModels());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.activeProvider).toBe('claude');
+    expect(result.current.filteredModels).toEqual(['claude-opus-4.6', 'claude-sonnet-4.6']);
+
+    updateCachedActiveProvider('copilot');
+
+    await waitFor(() => {
+      expect(result.current.activeProvider).toBe('copilot');
+    });
+    expect(result.current.filteredModels).toEqual(['gpt-5.1']);
   });
 });
 

--- a/packages/web/src/hooks/useModels.ts
+++ b/packages/web/src/hooks/useModels.ts
@@ -63,6 +63,11 @@ export function deriveModelName(id: string): string {
 
 let cachedData: { models: string[]; defaults: Record<string, string[]>; modelsByProvider: Record<string, string[]>; activeProvider: string } | null = null;
 let fetchPromise: Promise<void> | null = null;
+const subscribers = new Set<() => void>();
+
+function notifySubscribers(): void {
+  subscribers.forEach((subscriber) => subscriber());
+}
 
 function fetchModels(): Promise<void> {
   if (cachedData) return Promise.resolve();
@@ -75,6 +80,7 @@ function fetchModels(): Promise<void> {
         modelsByProvider: data.modelsByProvider ?? {},
         activeProvider: data.activeProvider ?? 'copilot',
       };
+      notifySubscribers();
     })
     .catch(() => {
       // Allow retry on next mount
@@ -91,16 +97,21 @@ export function useModels(): ModelsData {
   const [, setTick] = useState(0);
 
   useEffect(() => {
+    const rerender = () => setTick((t) => t + 1);
+    subscribers.add(rerender);
+
     if (cachedData) {
       setLoading(false);
-      return;
+      return () => {
+        subscribers.delete(rerender);
+      };
     }
     let mounted = true;
     fetchModels()
       .then(() => {
         if (mounted) {
           setLoading(false);
-          setTick((t) => t + 1);
+          rerender();
         }
       })
       .catch(() => {
@@ -109,7 +120,10 @@ export function useModels(): ModelsData {
           setLoading(false);
         }
       });
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+      subscribers.delete(rerender);
+    };
   }, []);
 
   const models = cachedData?.models ?? [];
@@ -131,8 +145,15 @@ export function useModels(): ModelsData {
   };
 }
 
+export function updateCachedActiveProvider(activeProvider: string): void {
+  if (!cachedData || cachedData.activeProvider === activeProvider) return;
+  cachedData = { ...cachedData, activeProvider };
+  notifySubscribers();
+}
+
 /** Clear cached data (useful for tests) */
 export function _resetModelsCache(): void {
   cachedData = null;
   fetchPromise = null;
+  subscribers.clear();
 }


### PR DESCRIPTION
## Summary
- keep disabled providers from presenting a normal activation CTA in provider settings
- align ProvidersSection coverage with the installed+disabled case via d10fe108aeab844216c99f70ed7c3005d9587c3a

## Validation
- npm run test --workspace=packages/web -- src/components/Settings/__tests__/ProvidersSection.test.tsx
- QA, code review, critical review, and readability review completed clean in this session