### PR TITLE
Enable Gemini 3.1 Pro and assign it to critical-reviewer

### DIFF
--- a/packages/server/src/__tests__/ModelConfig.test.ts
+++ b/packages/server/src/__tests__/ModelConfig.test.ts
@@ -108,7 +108,7 @@ describe('ModelConfigDefaults', () => {
     });
 
     it('has critical-reviewer defaults', () => {
-      expect(DEFAULT_MODEL_CONFIG['critical-reviewer']).toEqual(['gpt-5.5']);
+      expect(DEFAULT_MODEL_CONFIG['critical-reviewer']).toEqual(['gemini-3.1-pro-preview', 'gpt-5.5']);
     });
 
     it('has readability-reviewer defaults', () => {
@@ -120,7 +120,7 @@ describe('ModelConfigDefaults', () => {
     });
 
     it('has secretary defaults', () => {
-      expect(DEFAULT_MODEL_CONFIG.secretary).toEqual(['gpt-5.1', 'gpt-4.1']);
+      expect(DEFAULT_MODEL_CONFIG.secretary).toEqual(['gpt-5.1']);
     });
 
     it('has qa-tester defaults', () => {

--- a/packages/server/src/agents/RoleRegistry.ts
+++ b/packages/server/src/agents/RoleRegistry.ts
@@ -104,7 +104,7 @@ Security is a foundational design principle, not an afterthought. Review all cod
     color: '#f85149',
     icon: '🛡️',
     builtIn: true,
-    model: 'gpt-5.5',
+    model: 'gemini-3.1-pro-preview',
   },
   {
     id: 'readability-reviewer',
@@ -538,7 +538,7 @@ This ensures the task is properly tracked in the DAG with correct dependencies, 
 
 == MODEL SELECTION ==
 Each role has a recommended default model, but YOU decide the best model for each task. Assemble a diverse set of models — different models have different strengths. Override the default by setting "model" in CREATE_AGENT.
-Known model families: Claude (opus, sonnet, haiku — e.g. claude-opus-4.8, claude-sonnet-4.6), GPT (gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex, gpt-4.1), Gemini (gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash).
+Known model families: Claude (opus, sonnet, haiku — e.g. claude-opus-4.8, claude-sonnet-4.6), GPT (gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex, gpt-4.1), Gemini (gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3.5-flash, gemini-2.5-pro).
 Tips: Use Opus/GPT-5.3 for complex reasoning, Sonnet/GPT-5.2 for fast coding, Haiku/GPT-4.1 for quick simple tasks, Gemini for a fresh perspective.
 
 == PROVIDER SELECTION ==

--- a/packages/server/src/projects/ModelConfigDefaults.ts
+++ b/packages/server/src/projects/ModelConfigDefaults.ts
@@ -22,7 +22,10 @@ export const KNOWN_MODEL_IDS: readonly string[] = [
   'claude-sonnet-4.5',
   'claude-sonnet-4',
   'claude-haiku-4.5',
-  // Google
+  // Google — Copilot CLI native ids (verified against the live CLI bundle)
+  'gemini-3.1-pro-preview',
+  'gemini-3.5-flash',
+  // Google — native Gemini CLI ids
   'gemini-3.1-pro',
   'gemini-3.1-flash',
   'gemini-3.1-flash-lite',
@@ -65,10 +68,10 @@ export const DEFAULT_MODEL_CONFIG: ProjectModelConfig = {
   developer: ['claude-opus-4.8'],
   architect: ['claude-opus-4.8'],
   'code-reviewer': ['gpt-5.3-codex', 'claude-opus-4.8'],
-  'critical-reviewer': ['gpt-5.5'],
+  'critical-reviewer': ['gemini-3.1-pro-preview', 'gpt-5.5'],
   'readability-reviewer': ['claude-sonnet-4.6'],
   'tech-writer': ['gpt-5.5', 'claude-sonnet-4.6'],
-  secretary: ['gpt-5.1', 'gpt-4.1'],
+  secretary: ['gpt-5.1'],
   'qa-tester': ['claude-sonnet-4.6'],
   designer: ['claude-opus-4.8'],
   'product-manager': ['gpt-5.5'],

--- a/packages/server/src/projects/ModelConfigDefaults.ts
+++ b/packages/server/src/projects/ModelConfigDefaults.ts
@@ -22,10 +22,11 @@ export const KNOWN_MODEL_IDS: readonly string[] = [
   'claude-sonnet-4.5',
   'claude-sonnet-4',
   'claude-haiku-4.5',
-  // Google — Copilot CLI native ids (verified against the live CLI bundle)
+  // Google (Gemini) — superset across providers; per-provider availability is
+  // gated by ProviderRegistry.restrictedModels (e.g. Copilot exposes the
+  // *-preview ids verified against the live CLI bundle).
   'gemini-3.1-pro-preview',
   'gemini-3.5-flash',
-  // Google — native Gemini CLI ids
   'gemini-3.1-pro',
   'gemini-3.1-flash',
   'gemini-3.1-flash-lite',

--- a/packages/shared/src/domain/provider.ts
+++ b/packages/shared/src/domain/provider.ts
@@ -150,7 +150,7 @@ export const PROVIDER_REGISTRY: Record<ProviderId, ProviderDefinition> = {
     supportsAgentFlag: true,
     modelArgStrategy: 'flag',
     nativeModelProviders: ['anthropic', 'openai', 'google', 'xai'],
-    restrictedModels: { google: ['gemini-3-pro-preview'] },
+    restrictedModels: { google: ['gemini-3-pro-preview', 'gemini-3.1-pro-preview', 'gemini-3.5-flash'] },
     tierModels: { fast: 'claude-haiku-4.5', standard: 'claude-sonnet-4.6', premium: 'claude-opus-4.8' },
     authCommand: 'gh auth status',
     authLabel: 'Authenticated via GitHub',

--- a/packages/web/src/constants/models.ts
+++ b/packages/web/src/constants/models.ts
@@ -23,6 +23,11 @@ export const AVAILABLE_MODELS: string[] = [
   'claude-sonnet-4',
   'claude-haiku-4.5',
   // Google
+  'gemini-3.1-pro-preview',
+  'gemini-3.5-flash',
+  'gemini-3.1-pro',
+  'gemini-3.1-flash',
+  'gemini-3.1-flash-lite',
   'gemini-3-pro-preview',
   'gemini-3-flash-preview',
   'gemini-2.5-pro',
@@ -40,4 +45,14 @@ export const AVAILABLE_MODELS: string[] = [
   'gpt-5.1-codex-mini',
   'gpt-5-mini',
   'gpt-4.1',
+  // Moonshot (Kimi)
+  'moonshot-v1-8k',
+  'moonshot-v1-32k',
+  'moonshot-v1-128k',
+  'kimi-latest',
+  // Qwen
+  'qwen-turbo',
+  'qwen-plus',
+  'qwen-max',
+  'qwen-coder-plus-latest',
 ];


### PR DESCRIPTION
## Summary

The flightdeck model lists had drifted from what the Copilot CLI actually exposes. The CLI ships `gemini-3.1-pro-preview` and `gemini-3.5-flash` (verified against the live `v1.0.60` bundle), but:

- `KNOWN_MODEL_IDS` only had the no-suffix `gemini-3.1-pro`, and
- Copilot's `restrictedModels.google` whitelist only allowed the older `gemini-3-pro-preview`.

So Gemini 3.1 was neither selectable in the UI nor valid under the Copilot provider, even though the CLI supports it.

## Changes

- **`shared/.../provider.ts`** — add `gemini-3.1-pro-preview`, `gemini-3.5-flash` to Copilot's `restrictedModels.google` whitelist.
- **`server/.../ModelConfigDefaults.ts`**
  - add the two real Copilot ids to `KNOWN_MODEL_IDS` (validation + `/models` endpoint).
  - set **`critical-reviewer`** default to `gemini-3.1-pro-preview` (`gpt-5.5` kept as an allowed alternative) → **GPT + Gemini + Claude** three-family review fan-out (code-reviewer = GPT, critical-reviewer = Gemini, readability-reviewer = Claude).
  - drop the unused `gpt-4.1` alternative from `secretary` (default stays `gpt-5.1`).
- **`server/.../RoleRegistry.ts`** — sync critical-reviewer's built-in model and refresh the lead prompt's "Known model families" Gemini examples.
- **`web/.../constants/models.ts`** — re-sync the frontend fallback list with `KNOWN_MODEL_IDS` (Gemini 3.1, 3.5-flash, Moonshot, Qwen), per the file's own sync contract.
- **`ModelConfig.test.ts`** — update the critical-reviewer and secretary assertions.

## Testing

Targeted unit tests pass (no build/restart, no DB touched):

- `ModelConfigConsistency`, `ModelConfig`, `ProjectTemplates`, `AgentManager.modelConfig`, `ModelSelector`, `ModelResolver`, `ModelAvailability`, `ProviderManager`, `AcpAdapter` — all green.

The model-config consistency invariant (`RoleRegistry.model` == `DEFAULT_MODEL_CONFIG[role][0]`) is preserved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>