### PR TITLE
Bump version to 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2026-06-16
+
+### Changed
+
+- **Agent model lineup refreshed** — Updated default agent models to the latest generation and added a model-availability fallback so agents degrade gracefully when a configured model is unavailable (#266).
+- **Critical reviewer uses Gemini 3.1 Pro** — Enabled Gemini 3.1 Pro and assigned it to the critical-reviewer role for cross-family adversarial review (#269).
+- **Secretary default model** — Set the secretary's default model to Claude Sonnet 4.6 and aligned the shared/server/web model id lists (#270, #272).
+
 ## [0.4.4] - 2026-05-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flightdeck-ai/flightdeck",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flightdeck-ai/flightdeck",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "bundleDependencies": [
         "@flightdeck/shared"
       ],
@@ -13441,7 +13441,7 @@
     },
     "packages/docs": {
       "name": "@flightdeck/docs",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "devDependencies": {
         "vitepress": "^1.6.4",
         "vue": "^3.5.29"
@@ -13449,7 +13449,7 @@
     },
     "packages/server": {
       "name": "@flightdeck/server",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.16.1",
         "@flightdeck/shared": "*",
@@ -13480,14 +13480,14 @@
     },
     "packages/shared": {
       "name": "@flightdeck/shared",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "zod": "^4.3.6"
       }
     },
     "packages/web": {
       "name": "@flightdeck/web",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flightdeck-ai/flightdeck",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Flightdeck - AI crew management platform",
   "license": "MIT",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flightdeck/docs",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flightdeck/server",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flightdeck/shared",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Shared types and Zod schemas for flightdeck server and web packages",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flightdeck/web",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps Flightdeck from **0.4.4 → 0.4.5** across all workspace packages and the lockfile, and adds a CHANGELOG entry for the changes that landed on `main` since 0.4.4.

### Changes
- `version` bumped to `0.4.5` in root + `packages/{server,web,shared,docs}/package.json`
- `package-lock.json` workspace versions updated (surgical — no dependency drift)
- `CHANGELOG.md` `[0.4.5]` section summarizing:
  - Agent model lineup refresh + availability fallback (#266)
  - Critical reviewer → Gemini 3.1 Pro (#269)
  - Secretary default model + model-id list alignment (#270, #272)

### Notes for the maintainer
- **Tagging/publishing is intentionally left to you.** The npm release workflow triggers on a `v*` tag push and publishes `@flightdeck-ai/flightdeck` via OIDC from this repo's `release` environment — neither of which a fork can/should do. This PR only prepares the version + changelog so you can decide whether to cut the release.
- Opened as a **draft** for your review.

🤖 Drafted with GitHub Copilot CLI.